### PR TITLE
qmake project: option for static build and libunwind

### DIFF
--- a/monero-core.pro
+++ b/monero-core.pro
@@ -69,8 +69,10 @@ win32 {
 }
 
 linux {
+    CONFIG(static) {
+        LIBS+= -Wl,-Bstatic
+    }
     LIBS+= \
-        -Wl,-Bstatic \
         -lboost_serialization \
         -lboost_thread \
         -lboost_system \

--- a/monero-core.pro
+++ b/monero-core.pro
@@ -84,6 +84,7 @@ linux {
         -lssl \
         -lcrypto \
         -Wl,-Bdynamic \
+        -lunwind \
         -ldl
 }
 


### PR DESCRIPTION
Distribution packages should link dynamically (static libs for dependencies are not available for most packages), so let's add an option for choosing static build when needed but also allowing dynamic build.

Also, libunwind was needed to link on Arch Linux, so added it.