### PR TITLE
Bitmonero renamings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 
 pushd $(pwd)
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-BITMOMERO_DIR=bitmonero
+MONERO_DIR=monero
 
-if [ ! -d $BITMOMERO_DIR ]; then 
+if [ ! -d $MONERO_DIR ]; then 
     $SHELL get_libwallet_api.sh
 fi
  

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -52,7 +52,7 @@ popd
 
 # unbound is one more dependency. can't be merged to the wallet_merged
 # since filename conflict (random.c.obj)
-# for Linux, we use libunbound from repository, so we don't need to build it
+# for Linux, we use libunbound shipped with the system, so we don't need to build it
 
 if [ "$PLATFORM" != "Linux" ]; then
     echo "Building libunbound..."

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -38,10 +38,10 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     cmake -D CMAKE_BUILD_TYPE=Release -D STATIC=ON -D BUILD_GUI_DEPS=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR"  ../..
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
     # Do something under Windows NT platform
-    cmake -D CMAKE_BUILD_TYPE=Release -D STATIC=ON -D BUILD_GUI_DEPS=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
+    cmake -D CMAKE_BUILD_TYPE=Release -D STATIC=ON -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
     # Do something under Windows NT platform
-    cmake -D CMAKE_BUILD_TYPE=Release -D STATIC=ON -D BUILD_GUI_DEPS=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
+    cmake -D CMAKE_BUILD_TYPE=Release -D STATIC=ON -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
 fi
 
 
@@ -53,7 +53,8 @@ popd
 # unbound is one more dependency. can't be merged to the wallet_merged
 # since filename conflict (random.c.obj)
 # for Linux, we use libunbound from repository, so we don't need to build it
-if [ $PLATFORM != "Linux" ]; then
+
+if [ "$PLATFORM" != "Linux" ]; then
     echo "Building libunbound..."
     pushd $MONERO_DIR/build/release/external/unbound
     make -j$CPU_CORE_COUNT

--- a/monero-core.pro
+++ b/monero-core.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 
 QT += qml quick widgets
 
-WALLET_ROOT=$$PWD/bitmonero
+WALLET_ROOT=$$PWD/monero
 
 CONFIG += c++11
 
@@ -86,7 +86,8 @@ linux {
         -lssl \
         -lcrypto \
         -Wl,-Bdynamic \
-        -lunwind \
+        # currently monero has an issue with "static" build and linunwind-dev
+        # -lunwind \
         -ldl
 }
 


### PR DESCRIPTION
changes regarding bitmonero->monero renamings + disabled link to libunwind for Linux build (https://github.com/monero-project/monero/issues/1090).