### PR TITLE
Fix Windows MSYS2 build

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -26,12 +26,14 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import QtQuick 2.2
+
 import QtQml 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.2
+import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.1
 import QtGraphicalEffects 1.0
-import "pages"
+
+import "./pages"
 
 Rectangle {
     id: root

--- a/monero-core.pro
+++ b/monero-core.pro
@@ -194,7 +194,7 @@ macx {
 }
 
 win32 {
-    deploy.commands += windeployqt $$sprintf("%1/%2/%3.exe", $$OUT_PWD, $$DESTDIR, $$TARGET) -qmldir=$$PWD
+    deploy.commands += windeployqt $$sprintf("%1/%2/%3.exe", $$OUT_PWD, $$DESTDIR, $$TARGET) -release -qmldir=$$PWD
     deploy.commands += $$escape_expand(\n\t) $$PWD/windeploy_helper.sh $$DESTDIR
 }
 


### PR DESCRIPTION
module QtQuick.Controls 2.0 should not be used until Qt 5.7 available in msys2.  Currently it's only 5.6 and it doesn't contain that module.