### PR TITLE
make build script exit with non-zero status on error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
 source ./utils.sh
 pushd $(pwd)
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
I'm trying to integrate with some things like buildbot, and there are many different ways the build.sh script errors but still exits with status 0. This should help that a bit by making it exit with a non-zero status when there is an error from any of the commands.