### PR TITLE
Switch button position on password modal

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -37,7 +37,7 @@ import QtQuick.Controls.Styles 1.4
 Dialog {
     id: root
     property alias password: passwordInput.text
-    standardButtons: StandardButton.Ok + StandardButton.Cancel
+    standardButtons:  StandardButton.Cancel + StandardButton.Ok
     ColumnLayout {
         id: column
         anchors.fill: parent


### PR DESCRIPTION
Buttons are the wrong way around (against convention)

Not tested.