### PR TITLE
Fix erroneous DateTime & small README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ TODO
 
 7. Before running the GUI, it's recommended that you have the Monero daemon running in the background.
 
-	`./monerod --rpc-bind-port 38081`
+	`./monerod`
 
 8. Run the GUI client.
 

--- a/src/libwalletqt/TransactionHistory.cpp
+++ b/src/libwalletqt/TransactionHistory.cpp
@@ -29,8 +29,8 @@ QList<TransactionInfo *> TransactionHistory::getAll() const
     qDeleteAll(m_tinfo);
     m_tinfo.clear();
 
-    QDateTime firstDateTime = QDateTime::currentDateTime().addDays(1); // tomorrow (guard against jitter and timezones)
-    QDateTime lastDateTime  = QDateTime(QDate(2014, 4, 18)); // the genesis block
+    QDateTime firstDateTime = QDateTime(QDate(2014, 4, 18)); // the genesis block
+    QDateTime lastDateTime  = QDateTime::currentDateTime().addDays(1); // tomorrow (guard against jitter and timezones)
 
     TransactionHistory * parent = const_cast<TransactionHistory*>(this);
     for (const auto i : m_pimpl->getAll()) {


### PR DESCRIPTION
1. `firstDateTime` was set to current date, whereas `lastDateTime` was set to the genesis block. This should be the other way around. [This](https://i.imgur.com/4kwb8Bh.png) is how it looked before the PR. 

2. The GUI connects to mainnet by default. Thus, we should remove the `--rpc-bind-port 38081` (testnet) from the README. 