### PR TITLE
Fix small amounts from being conflated with zero

### DIFF
--- a/BasicPanel.qml
+++ b/BasicPanel.qml
@@ -46,7 +46,7 @@ Rectangle {
     property alias balanceText : balanceText.text;
     property alias unlockedBalanceText : availableBalanceText.text;
     // repeating signal to the outside world
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount,
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount,
                           int priority, string description)
 
     Connections {

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -50,7 +50,7 @@ Rectangle {
     property Settings settingsView: Settings { }
 
 
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount, int priority, string description)
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount, int priority, string description)
     signal generatePaymentIdInvoked()
     signal checkPaymentClicked(string address, string txid, string txkey);
 

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -33,7 +33,7 @@ import "../components"
 
 Rectangle {
     id: root
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount,
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount,
                           int priority, string description)
 
     color: "#F0EEEE"


### PR DESCRIPTION
Something like 0.000000000012 was converted to 1.2e-11
by the conversion to double, and that was rejected by
the Cryptonote parser.