### PR TITLE
Transfer: display number of split tx in transaction confirmation popup

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2015, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -398,7 +398,8 @@ ApplicationWindow {
                         + qsTr("\n\nAmount: ") + walletManager.displayAmount(transaction.amount)
                         + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee)
                         + qsTr("\n\nMixin: ") + mixinCount
-                        + qsTr("\n\nDescription: ") + transactionDescription;
+                        + qsTr("\n\Number of transactions: ") + transaction.txCount
+                        + qsTr("\n\nDescription: ") + transactionDescription
                         + translationManager.emptyString
             transactionConfirmationPopup.icon = StandardIcon.Question
             transactionConfirmationPopup.open()
@@ -417,9 +418,9 @@ ApplicationWindow {
                     ", description: ", description);
 
         showProcessingSplash("Creating transaction");
-        
+
         transactionDescription = description;
-        
+
         // validate amount;
         var amountxmr = walletManager.amountFromString(amount);
         console.log("integer amount: ", amountxmr);

--- a/src/libwalletqt/PendingTransaction.cpp
+++ b/src/libwalletqt/PendingTransaction.cpp
@@ -31,13 +31,20 @@ quint64 PendingTransaction::fee() const
     return m_pimpl->fee();
 }
 
-QList<QString> PendingTransaction::txid() const
+
+QStringList PendingTransaction::txid() const
 {
-    QList<QString> list;
+    QStringList list;
     std::vector<std::string> txid = m_pimpl->txid();
     for (const auto &t: txid)
         list.append(QString::fromStdString(t));
     return list;
+}
+
+
+quint64 PendingTransaction::txCount() const
+{
+    return m_pimpl->txCount();
 }
 
 PendingTransaction::PendingTransaction(Bitmonero::PendingTransaction *pt, QObject *parent)

--- a/src/libwalletqt/PendingTransaction.h
+++ b/src/libwalletqt/PendingTransaction.h
@@ -17,7 +17,8 @@ class PendingTransaction : public QObject
     Q_PROPERTY(quint64 amount READ amount)
     Q_PROPERTY(quint64 dust READ dust)
     Q_PROPERTY(quint64 fee READ fee)
-    Q_PROPERTY(QList<QString> txid READ txid)
+    Q_PROPERTY(QStringList txid READ txid)
+    Q_PROPERTY(quint64 txCount READ txCount)
 
 public:
     enum Status {
@@ -40,7 +41,9 @@ public:
     quint64 amount() const;
     quint64 dust() const;
     quint64 fee() const;
-    QList<QString> txid() const;
+    QStringList txid() const;
+    quint64 txCount() const;
+
 private:
     explicit PendingTransaction(Bitmonero::PendingTransaction * pt, QObject *parent = 0);
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/411612/20076161/6752fd04-a548-11e6-8624-54552f93ce08.png)

Depends on https://github.com/monero-project/monero/pull/1307
