### PR TITLE
Call the mnemonic seed 'Seed' instead of 'Words' in the Create Account Wizard

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -136,7 +136,7 @@ Rectangle {
         anchors.rightMargin: 17
         anchors.topMargin: 30
         fontSize: 14
-        text: qsTr("Privacy Level") + translationManager.emptyString
+        text: qsTr("Privacy level") + translationManager.emptyString
     }
 
     PrivacyLevel {

--- a/wizard/WizardFinish.qml
+++ b/wizard/WizardFinish.qml
@@ -53,7 +53,7 @@ Item {
         return "<table>"
             + trStart + qsTr("Language") + trMiddle + wizard.settings["language"] + trEnd
             + trStart + qsTr("Account name") + trMiddle + wizard.settings["account_name"] + trEnd
-            + trStart + qsTr("Words") + trMiddle + wizard.settings["wallet"].seed + trEnd
+            + trStart + qsTr("Seed") + trMiddle + wizard.settings["wallet"].seed + trEnd
             + trStart + qsTr("Wallet path") + trMiddle + wizard.settings["wallet_path"] + trEnd
             // + trStart + qsTr("Auto donations") + trMiddle + autoDonationText + trEnd
             // + (autoDonationEnabled


### PR DESCRIPTION
Also, make the second word of "Privacy level" lowercase to follow suit with the rest of the titles.