### PR TITLE
Do not open wallet from default location automatically

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -349,24 +349,12 @@ ApplicationWindow {
         currentWallet.history.refresh() // this will refresh model
     }
 
-
-
     function walletsFound() {
         if (persistentSettings.wallet_path.length > 0) {
-            var lastOpenedExists = walletManager.walletExists(persistentSettings.wallet_path);
-            if (lastOpenedExists) {
-                console.log("Last opened wallet exists in:",persistentSettings.wallet_path)
-            }
-         }
-
-        // Check if wallets exists in default path
-        var wallets = walletManager.findWallets(moneroAccountsDir);
-        if (wallets.length === 0) {
-            wallets = walletManager.findWallets(applicationDirectory);
+            return walletManager.walletExists(persistentSettings.wallet_path);
         }
-        return (wallets.length > 0 || lastOpenedExists);
+        return false;
     }
-
 
     function onTransactionCreated(pendingTransaction,address,paymentId,mixinCount){
         console.log("Transaction created");


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero-core/issues/153

Automatic opening of wallet from default location is not needed anymore when we have the wallet picker. (Note: Not to be mistaken of automatic opening of last opened wallet which is still working)