### PR TITLE
History: do not dereference a null model

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -48,7 +48,7 @@ Rectangle {
     color: "#F0EEEE"
 
     function getSelectedAmount() {
-      if (typeof model === 'undefined')
+      if (typeof model === 'undefined' || model == null)
         return ""
       var total = 0
       var count = model.rowCount()


### PR DESCRIPTION
Seems "null" objects in Javascript can either be null, or
be non null but with a type of 'undefined' (as a string).

Whatever.