### PR TITLE
Change OrganizationName to MoneroProject

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
 
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
-    app.setOrganizationName("The Monero Project");
+    app.setOrganizationName("MoneroProject");
 
     filter *eventFilter = new filter;
     app.installEventFilter(eventFilter);


### PR DESCRIPTION
Get rid of spaces, makes for ugly .config path on POSIX systems
Obsoletes #96