### PR TITLE
Receive: use atomic units for amount in the QR code encoded URI

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -63,7 +63,7 @@ Rectangle {
         var amount = amountLine.text.trim()
         if (amount !== "") {
           s += (nfields++ ? "&" : "?")
-          s += "tx_amount=" + amount
+          s += "tx_amount=" + walletManager.amountFromString(amount)
         }
         var pid = paymentIdLine.text.trim()
         if (pid !== "") {


### PR DESCRIPTION
This is what the spec mandates