### PR TITLE
Daemon manager

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -32,6 +32,7 @@ import QtQuick 2.2
 import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.1
 import QtGraphicalEffects 1.0
+import moneroComponents.Wallet 1.0
 
 import "./pages"
 
@@ -56,9 +57,6 @@ Rectangle {
     signal generatePaymentIdInvoked()
     signal checkPaymentClicked(string address, string txid, string txkey);
 
-    // Disable transfer page if daemon isnt fully synced
-    enabled: (currentView !== transferView || appWindow.daemonSynced)
-
     color: "#F0EEEE"
 
     onCurrentViewChanged: {
@@ -70,6 +68,10 @@ Rectangle {
                 currentView.onPageCompleted();
             }
         }
+    }
+
+    function updateStatus(){
+        transferView.updateStatus();
     }
 
 
@@ -292,14 +294,6 @@ Rectangle {
         color: "#DBDBDB"
 
     }
-    Rectangle {
-        id:desaturate
-        color:"black"
-        anchors.fill: parent
-        opacity: 0.1
-        visible: (root.enabled)? 0 : 1;
-    }
-
 
     /* connect "payment" click */
     Connections {

--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -90,8 +90,8 @@ Window {
                 KeyNavigation.tab: cancelButton
                 onClicked: {
                     daemonManager.start();
-                    root.accepted()
                     root.close()
+                   // root.accepted()
                 }
             }
 

--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -41,6 +41,7 @@ Window {
     flags: Qt.Window | Qt.FramelessWindowHint
 
     signal rejected()
+    signal started();
 
     function open() {
         show()
@@ -91,7 +92,7 @@ Window {
                 onClicked: {
                     daemonManager.start();
                     root.close()
-                   // root.accepted()
+                    root.started()
                 }
             }
 
@@ -106,8 +107,8 @@ Window {
                 text: qsTr("Cancel")
 
                 onClicked: {
-                    root.rejected()
                     root.close()
+                    root.rejected()
                 }
             }
         }

--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -1,0 +1,119 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import QtQuick 2.0
+import QtQuick.Controls 1.4
+import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.1
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.0
+
+import "../components" as MoneroComponents
+
+Window {
+    id: root
+    modality: Qt.ApplicationModal
+    flags: Qt.Window | Qt.FramelessWindowHint
+
+    signal rejected()
+
+    function open() {
+        show()
+    }
+
+    // TODO: implement without hardcoding sizes
+    width: 480
+    height: 200
+
+    ColumnLayout {
+        id: mainLayout
+        spacing: 10
+        anchors { fill: parent; margins: 35 }
+
+        ColumnLayout {
+            id: column
+            //anchors {fill: parent; margins: 16 }
+            Layout.alignment: Qt.AlignHCenter
+
+            Label {
+                text: qsTr("Daemon doesn't appear to be running")
+                Layout.alignment: Qt.AlignHCenter
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 24
+                font.family: "Arial"
+                color: "#555555"
+            }
+
+        }
+
+        RowLayout {
+            id: buttons
+            spacing: 60
+            Layout.alignment: Qt.AlignHCenter
+
+            MoneroComponents.StandardButton {
+                id: okButton
+                width: 120
+                fontSize: 14
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                text: qsTr("Start daemon")
+                KeyNavigation.tab: cancelButton
+                onClicked: {
+                    daemonManager.start();
+                    root.accepted()
+                    root.close()
+                }
+            }
+
+            MoneroComponents.StandardButton {
+                id: cancelButton
+                width: 120
+                fontSize: 14
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                text: qsTr("Cancel")
+
+                onClicked: {
+                    root.rejected()
+                    root.close()
+                }
+            }
+        }
+    }
+
+}
+
+
+

--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -90,8 +90,8 @@ Window {
                 text: qsTr("Start daemon")
                 KeyNavigation.tab: cancelButton
                 onClicked: {
-                    daemonManager.start();
                     root.close()
+                    appWindow.startDaemon();
                     root.started()
                 }
             }

--- a/components/DaemonProgress.qml
+++ b/components/DaemonProgress.qml
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import QtQuick 2.0
+import moneroComponents.Wallet 1.0
 
 Item {
     id: item
@@ -46,7 +47,7 @@ Item {
 
             // TODO: lower daemon block height cache, ttl and refresh interval?
 
-            item.visible = (currentBlock < targetBlock)
+            item.visible = (currentWallet.connected !== Wallet.ConnectionStatus_Disconnected) && (currentBlock < targetBlock)
 
         }
     }

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -69,6 +69,7 @@ ListView {
 
     StandardDialog {
         id: detailsPopup
+        width:600
         cancelVisible: false
         okVisible: true
     }

--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -143,8 +143,8 @@ Window {
                 text: qsTr("Cancel")
                 KeyNavigation.tab: passwordInput
                 onClicked: {
-                    root.rejected()
                     root.close()
+                    root.rejected()
                 }
             }
             MoneroComponents.StandardButton {
@@ -158,8 +158,8 @@ Window {
                 text: qsTr("Ok")
                 KeyNavigation.tab: cancelButton
                 onClicked: {
-                    root.accepted()
                     root.close()
+                    root.accepted()
                 }
             }
         }

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -40,9 +40,11 @@ Window {
     modality: Qt.ApplicationModal
     flags: Qt.Window | Qt.FramelessWindowHint
     property alias title: dialogTitle.text
-    property alias content: dialogContent.text
+    property alias text: dialogContent.text
+    property alias content: root.text
     property alias cancelVisible: cancelButton.visible
     property alias okVisible: okButton.visible
+    property var icon
 
     // same signals as Dialog has
     signal accepted()
@@ -54,8 +56,8 @@ Window {
     }
 
     // TODO: implement without hardcoding sizes
-    width: 600
-    height: 480
+    width: 800
+    height: 580
 
     ColumnLayout {
         id: mainLayout
@@ -80,6 +82,8 @@ Window {
         RowLayout {
             TextArea {
                 id : dialogContent
+                width: 750
+                height: 480
                 Layout.fillWidth: true
                 font.family: "Arial"
                 textFormat: TextEdit.AutoText

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -44,6 +44,7 @@ Window {
     property alias content: root.text
     property alias cancelVisible: cancelButton.visible
     property alias okVisible: okButton.visible
+    property alias textArea: dialogContent
     property var icon
 
     // same signals as Dialog has
@@ -56,8 +57,8 @@ Window {
     }
 
     // TODO: implement without hardcoding sizes
-    width: 800
-    height: 580
+    width:  480
+    height: 280
 
     ColumnLayout {
         id: mainLayout
@@ -82,9 +83,8 @@ Window {
         RowLayout {
             TextArea {
                 id : dialogContent
-                width: 750
-                height: 480
                 Layout.fillWidth: true
+                Layout.fillHeight: true
                 font.family: "Arial"
                 textFormat: TextEdit.AutoText
                 readOnly: true

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -119,6 +119,7 @@ Window {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 text: qsTr("Cancel")
+                KeyNavigation.tab: passwordInput
                 onClicked: {
                     root.rejected()
                     root.close()

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -109,8 +109,9 @@ Window {
                 text: qsTr("Ok")
                 KeyNavigation.tab: cancelButton
                 onClicked: {
-                    root.accepted()
                     root.close()
+                    root.accepted()
+
                 }
             }
 
@@ -125,8 +126,8 @@ Window {
                 text: qsTr("Cancel")
                 KeyNavigation.tab: passwordInput
                 onClicked: {
-                    root.rejected()
                     root.close()
+                    root.rejected()
                 }
             }
         }

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -124,7 +124,6 @@ Window {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 text: qsTr("Cancel")
-                KeyNavigation.tab: passwordInput
                 onClicked: {
                     root.close()
                     root.rejected()

--- a/main.cpp
+++ b/main.cpp
@@ -51,8 +51,6 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    qDebug() << "app startd";
-
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("The Monero Project");
@@ -108,7 +106,7 @@ int main(int argc, char *argv[])
 
     engine.addImageProvider(QLatin1String("qrcode"), new QRCodeImageProvider());
 
-    engine.rootContext()->setContextProperty("daemonManager", DaemonManager::instance());
+    engine.rootContext()->setContextProperty("daemonManager", DaemonManager::instance(QCoreApplication::arguments()));
 
 //  export to QML monero accounts root directory
 //  wizard is talking about where

--- a/main.cpp
+++ b/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    qDebug() << "app startd";
+
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("The Monero Project");

--- a/main.cpp
+++ b/main.cpp
@@ -115,9 +115,6 @@ int main(int argc, char *argv[])
     QObject::connect(&app, SIGNAL(aboutToQuit()), daemonManager, SLOT(closing()));
     engine.rootContext()->setContextProperty("daemonManager", daemonManager);
 
-
->>>>>>> cc05e1a... Shutdown daemon and close wallet properly on app exit
-
 //  export to QML monero accounts root directory
 //  wizard is talking about where
 //  to save the wallet file (.keys, .bin), they have to be user-accessible for

--- a/main.cpp
+++ b/main.cpp
@@ -44,6 +44,7 @@
 #include "TransactionHistory.h"
 #include "model/TransactionHistoryModel.h"
 #include "model/TransactionHistorySortFilterModel.h"
+#include "daemon/DaemonManager.h"
 
 
 int main(int argc, char *argv[])
@@ -88,6 +89,8 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<TransactionInfo>("moneroComponents.TransactionInfo", 1, 0, "TransactionInfo",
                                                         "TransactionHistory can't be instantiated directly");
 
+    qmlRegisterUncreatableType<DaemonManager>("moneroComponents.DaemonManager", 1, 0, "DaemonManager",
+                                                   "DaemonManager can't be instantiated directly");
     qRegisterMetaType<PendingTransaction::Priority>();
     qRegisterMetaType<TransactionInfo::Direction>();
     qRegisterMetaType<TransactionHistoryModel::TransactionInfoRole>();
@@ -104,6 +107,8 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("translationManager", TranslationManager::instance());
 
     engine.addImageProvider(QLatin1String("qrcode"), new QRCodeImageProvider());
+
+    engine.rootContext()->setContextProperty("daemonManager", DaemonManager::instance());
 
 //  export to QML monero accounts root directory
 //  wizard is talking about where

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,7 @@
 #include <QtQml>
 #include <QStandardPaths>
 #include <QDebug>
+#include <QObject>
 #include "clipboardAdapter.h"
 #include "filter.h"
 #include "oscursor.h"
@@ -109,6 +110,13 @@ int main(int argc, char *argv[])
     engine.addImageProvider(QLatin1String("qrcode"), new QRCodeImageProvider());
 
     engine.rootContext()->setContextProperty("daemonManager", DaemonManager::instance(QCoreApplication::arguments()));
+
+    DaemonManager * daemonManager = DaemonManager::instance(QCoreApplication::arguments());
+    QObject::connect(&app, SIGNAL(aboutToQuit()), daemonManager, SLOT(closing()));
+    engine.rootContext()->setContextProperty("daemonManager", daemonManager);
+
+
+>>>>>>> cc05e1a... Shutdown daemon and close wallet properly on app exit
 
 //  export to QML monero accounts root directory
 //  wizard is talking about where

--- a/main.cpp
+++ b/main.cpp
@@ -108,10 +108,8 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("translationManager", TranslationManager::instance());
 
     engine.addImageProvider(QLatin1String("qrcode"), new QRCodeImageProvider());
-
-    engine.rootContext()->setContextProperty("daemonManager", DaemonManager::instance(QCoreApplication::arguments()));
-
-    DaemonManager * daemonManager = DaemonManager::instance(QCoreApplication::arguments());
+    const QStringList arguments = QCoreApplication::arguments();
+    DaemonManager * daemonManager = DaemonManager::instance(&arguments);
     QObject::connect(&app, SIGNAL(aboutToQuit()), daemonManager, SLOT(closing()));
     engine.rootContext()->setContextProperty("daemonManager", daemonManager);
 

--- a/main.qml
+++ b/main.qml
@@ -1058,5 +1058,7 @@ ApplicationWindow {
            walletManager.closeWallet(currentWallet);
            currentWallet = undefined
        }
+       // Stop daemon
+       daemonManager.stop();
     }
 }

--- a/main.qml
+++ b/main.qml
@@ -288,17 +288,17 @@ ApplicationWindow {
             hideProcessingSplash()
         }
 
+        // Daemon connected
+        leftPanel.networkStatus.connected = currentWallet.connected
+
         // Check daemon status
         var dCurrentBlock = currentWallet.daemonBlockChainHeight();
         var dTargetBlock = currentWallet.daemonBlockChainTargetHeight();
-        leftPanel.daemonProgress.updateProgress(dCurrentBlock,dTargetBlock);
-
-        // Daemon connected
-        leftPanel.networkStatus.connected = currentWallet.connected
 
         // Daemon fully synced
         // TODO: implement onDaemonSynced or similar in wallet API and don't start refresh thread before daemon is synced
         daemonSynced = (currentWallet.connected != Wallet.ConnectionStatus_Disconnected && dCurrentBlock >= dTargetBlock)
+        leftPanel.daemonProgress.updateProgress(dCurrentBlock,dTargetBlock);
 
         // If wallet isnt connected and no daemon is running - Ask
         if(currentWallet.connected === Wallet.ConnectionStatus_Disconnected && !daemonManager.running() && !walletInitialized){
@@ -336,6 +336,7 @@ ApplicationWindow {
         appWindow.showProcessingSplash(qsTr("Waiting for daemon to start..."))
         daemonManager.start();
     }
+
     function stopDaemon(){
         appWindow.showProcessingSplash(qsTr("Waiting for daemon to stop..."))
         daemonManager.stop();

--- a/main.qml
+++ b/main.qml
@@ -299,6 +299,7 @@ ApplicationWindow {
         // TODO: implement onDaemonSynced or similar in wallet API and don't start refresh thread before daemon is synced
         daemonSynced = (currentWallet.connected != Wallet.ConnectionStatus_Disconnected && dCurrentBlock >= dTargetBlock)
         leftPanel.daemonProgress.updateProgress(dCurrentBlock,dTargetBlock);
+        middlePanel.updateStatus();
 
         // If wallet isnt connected and no daemon is running - Ask
         if(currentWallet.connected === Wallet.ConnectionStatus_Disconnected && !daemonManager.running() && !walletInitialized){

--- a/main.qml
+++ b/main.qml
@@ -685,11 +685,11 @@ ApplicationWindow {
     // TODO: replace with customized popups
 
     // Information dialog
-    MessageDialog {
+    StandardDialog {
         // dynamically change onclose handler
         property var onCloseCallback
         id: informationPopup
-        standardButtons: StandardButton.Ok
+        cancelVisible: false
         onAccepted:  {
             if (onCloseCallback) {
                 onCloseCallback()
@@ -698,10 +698,10 @@ ApplicationWindow {
     }
 
     // Confrirmation aka question dialog
-    MessageDialog {
+    StandardDialog {
         id: transactionConfirmationPopup
-        standardButtons: StandardButton.Ok  + StandardButton.Cancel
         onAccepted: {
+            close();
             handleTransactionConfirmed()
         }
     }

--- a/main.qml
+++ b/main.qml
@@ -1053,12 +1053,13 @@ ApplicationWindow {
         }
     }
     onClosing: {
-       // Close and save to disk on app close
-       if (currentWallet != undefined) {
-           walletManager.closeWallet(currentWallet);
-           currentWallet = undefined
-       }
-       // Stop daemon
-       daemonManager.stop();
+        // Make sure wallet is closed before app exit (~Wallet() isn't always invoked)
+        // Daemon shutdown is handled with signal/slot in main.cpp
+        if (currentWallet != undefined) {
+            walletManager.closeWallet(currentWallet);
+            currentWallet = undefined
+        }
+        // Stop daemon
+        daemonManager.stop();
     }
 }

--- a/main.qml
+++ b/main.qml
@@ -318,6 +318,18 @@ ApplicationWindow {
         }
 
 
+
+
+       // daemonManager.daemonConsole();
+       // console.log("Daemon runnnig: ",daemonManager.running());
+
+        if(!daemonManager.running()){
+            daemonManagerDialog.open();
+        }
+
+
+
+
         onWalletUpdate();
     }
 
@@ -721,6 +733,10 @@ ApplicationWindow {
 
     }
 
+    DaemonManagerDialog {
+        id: daemonManagerDialog
+
+    }
 
     ProcessingSplash {
         id: splash

--- a/main.qml
+++ b/main.qml
@@ -213,6 +213,7 @@ ApplicationWindow {
         currentWallet.moneySpent.disconnect(onWalletMoneySent)
         currentWallet.moneyReceived.disconnect(onWalletMoneyReceived)
         currentWallet.transactionCreated.disconnect(onTransactionCreated)
+        currentWallet.connectionStatusChanged.disconnect(onWalletConnectionStatusChanged)
 
         currentWallet.refreshed.connect(onWalletRefresh)
         currentWallet.updated.connect(onWalletUpdate)
@@ -220,6 +221,7 @@ ApplicationWindow {
         currentWallet.moneySpent.connect(onWalletMoneySent)
         currentWallet.moneyReceived.connect(onWalletMoneyReceived)
         currentWallet.transactionCreated.connect(onTransactionCreated)
+        currentWallet.connectionStatusChanged.connect(onWalletConnectionStatusChanged)
 
 
         console.log("initializing with daemon address: ", persistentSettings.daemon_address)
@@ -231,6 +233,11 @@ ApplicationWindow {
     function walletPath() {
         var wallet_path = persistentSettings.wallet_path
         return wallet_path;
+    }
+
+    function onWalletConnectionStatusChanged(){
+        console.log("Wallet connection status changed")
+        middlePanel.updateStatus();
     }
 
     function onWalletOpened(wallet) {

--- a/main.qml
+++ b/main.qml
@@ -294,7 +294,7 @@ ApplicationWindow {
         daemonSynced = (currentWallet.connected != Wallet.ConnectionStatus_Disconnected && dCurrentBlock >= dTargetBlock)
 
         // If wallet isnt connected and no daemon is running - Ask
-        if(!currentWallet.connected && !daemonManager.running() && !walletInitialized){
+        if(currentWallet.connected === Wallet.ConnectionStatus_Disconnected && !daemonManager.running() && !walletInitialized){
             daemonManagerDialog.open();
         }
 

--- a/main.qml
+++ b/main.qml
@@ -325,6 +325,15 @@ ApplicationWindow {
         onWalletUpdate();
     }
 
+    function startDaemon(){
+        appWindow.showProcessingSplash(qsTr("Waiting for daemon to start..."))
+        daemonManager.start();
+    }
+    function stopDaemon(){
+        appWindow.showProcessingSplash(qsTr("Waiting for daemon to stop..."))
+        daemonManager.stop();
+    }
+
     function onDaemonStarted(){
         console.log("daemon started");
         daemonRunning = true;

--- a/monero-core.pro
+++ b/monero-core.pro
@@ -30,7 +30,8 @@ HEADERS += \
     src/model/TransactionHistorySortFilterModel.h \
     src/QR-Code-generator/BitBuffer.hpp \
     src/QR-Code-generator/QrCode.hpp \
-    src/QR-Code-generator/QrSegment.hpp
+    src/QR-Code-generator/QrSegment.hpp \
+    src/daemon/DaemonManager.h
 
 
 SOURCES += main.cpp \
@@ -49,7 +50,8 @@ SOURCES += main.cpp \
     src/model/TransactionHistorySortFilterModel.cpp \
     src/QR-Code-generator/BitBuffer.cpp \
     src/QR-Code-generator/QrCode.cpp \
-    src/QR-Code-generator/QrSegment.cpp
+    src/QR-Code-generator/QrSegment.cpp \
+    src/daemon/DaemonManager.cpp
 
 lupdate_only {
 SOURCES = *.qml \

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -37,7 +37,6 @@ import "../components"
 import moneroComponents.Clipboard 1.0
 
 Rectangle {
-
     property var daemonAddress
 
     color: "#F0EEEE"
@@ -268,6 +267,44 @@ Rectangle {
                 onClicked: {
                     console.log("closing wallet button clicked")
                     appWindow.showWizard();
+                }
+            }
+        }
+
+        RowLayout {
+            Label {
+                id: manageDaemonLabel
+                color: "#4A4949"
+                text: qsTr("Manage daemon") + translationManager.emptyString
+                fontSize: 16
+            }
+
+            StandardButton {
+                visible: true
+                id: startDaemonButton
+                width: 110
+                text: qsTr("Start daemon") + translationManager.emptyString
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                onClicked: {
+                    daemonManager.start();
+                }
+            }
+
+            StandardButton {
+                visible: false
+                id: stopDaemonButton
+                width: 110
+                text: qsTr("Stop daemon") + translationManager.emptyString
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                onClicked: {
+
+                    //daemonManager.stop();
                 }
             }
         }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -290,7 +290,7 @@ Rectangle {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 onClicked: {
-                    daemonManager.start();
+                    appWindow.startDaemon()
                 }
             }
 
@@ -305,7 +305,7 @@ Rectangle {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 onClicked: {
-                    daemonManager.stop();
+                    appWindow.stopDaemon()
                 }
             }
 

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -281,6 +281,7 @@ Rectangle {
 
             StandardButton {
                 visible: true
+                enabled: !appWindow.daemonRunning
                 id: startDaemonButton
                 width: 110
                 text: qsTr("Start daemon") + translationManager.emptyString
@@ -294,7 +295,8 @@ Rectangle {
             }
 
             StandardButton {
-                visible: false
+                visible: true
+                enabled: appWindow.daemonRunning
                 id: stopDaemonButton
                 width: 110
                 text: qsTr("Stop daemon") + translationManager.emptyString
@@ -303,8 +305,7 @@ Rectangle {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 onClicked: {
-
-                    //daemonManager.stop();
+                    daemonManager.stop();
                 }
             }
         }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -314,7 +314,7 @@ Rectangle {
              //  enabled: appWindow.daemonRunning
                 id: daemonConsolePopupButton
                 width: 110
-                text: qsTr("Show concole") + translationManager.emptyString
+                text: qsTr("Show log") + translationManager.emptyString
                 shadowReleasedColor: "#FF4304"
                 shadowPressedColor: "#B32D00"
                 releasedColor: "#FF6C3C"
@@ -331,10 +331,10 @@ Rectangle {
     // Daemon console
     StandardDialog {
         id: daemonConsolePopup
-        height:800
+        height:500
         width:800
         cancelVisible: false
-        title: qsTr("Daemon console")
+        title: qsTr("Daemon log")
         onAccepted: {
             close();
         }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -308,16 +308,56 @@ Rectangle {
                     daemonManager.stop();
                 }
             }
+
+            StandardButton {
+                visible: true
+             //  enabled: appWindow.daemonRunning
+                id: daemonConsolePopupButton
+                width: 110
+                text: qsTr("Show concole") + translationManager.emptyString
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                onClicked: {
+                    daemonConsolePopup.open();
+                }
+            }
+
         }
 
     }
 
+    // Daemon console
+    StandardDialog {
+        id: daemonConsolePopup
+        height:800
+        width:800
+        cancelVisible: false
+        title: qsTr("Daemon console")
+        onAccepted: {
+            close();
+        }
+    }
 
 
+    // fires on every page load
     function onPageCompleted() {
         console.log("Settings page loaded");
         initSettings();
     }
+
+    // fires only once
+    Component.onCompleted: {
+        daemonManager.daemonConsoleUpdated.connect(onDaemonConsoleUpdated)
+    }
+
+    function onDaemonConsoleUpdated(message){
+        // Update daemon console
+        daemonConsolePopup.textArea.append(message)
+    }
+
+
 
 
 }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -29,6 +29,7 @@
 import QtQuick 2.0
 import moneroComponents.PendingTransaction 1.0
 import "../components"
+import moneroComponents.Wallet 1.0
 
 
 Rectangle {
@@ -328,6 +329,71 @@ Rectangle {
         onClicked: {
             console.log("Transfer: sweepUnmixableClicked")
             root.sweepUnmixableClicked()
+
+        }
+    }
+
+    Rectangle {
+        id:desaturate
+        color:"black"
+        anchors.fill: parent
+        opacity: 0.1
+        visible: (root.enabled)? 0 : 1;
+    }
+
+    Rectangle {
+        x: root.width/2 - width/2
+        y: root.height/2 - height/2
+        height:statusText.paintedHeight + 50
+        width:statusText.paintedWidth + 40
+        visible: statusText.text != ""
+        opacity: 0.9
+
+        Text {
+            id: statusText
+            anchors.fill:parent
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
+    Component.onCompleted: {
+        //Disable password page until enabled by updateStatus
+        root.enabled = false
+    }
+
+    // fires on every page load
+    function onPageCompleted() {
+        console.log("transfer page loaded")
+        updateStatus();
+    }
+
+    //TODO: Add daemon sync status
+    //TODO: enable send page when we're connected and daemon is synced
+
+    function updateStatus() {
+        console.log("updated transfer page status")
+        if(typeof currentWallet === "undefined") {
+            statusText.text = qsTr("Wallet is not connected to daemon.")
+            return;
+        }
+
+        switch (currentWallet.connected) {
+        case Wallet.ConnectionStatus_Disconnected:
+            statusText.text = qsTr("Wallet is not connected to daemon.")
+            break
+        case Wallet.ConnectionStatus_WrongVersion:
+            statusText.text = qsTr("Connected daemon is not compatible with GUI. \n" +
+                                   "Please upgrade or connect to another daemon")
+            break
+        default:
+            if(!appWindow.daemonSynced){
+                statusText.text = qsTr("Waiting on daemon synchronization to finish")
+            } else {
+                // everything OK, enable transfer page
+                root.enabled = true;
+                statusText.text = "";
+            }
 
         }
     }

--- a/qml.qrc
+++ b/qml.qrc
@@ -120,5 +120,6 @@
         <file>components/DaemonProgress.qml</file>
         <file>components/StandardDialog.qml</file>
         <file>pages/Sign.qml</file>
+        <file>components/DaemonManagerDialog.qml</file>
     </qresource>
 </RCC>

--- a/qml.qrc
+++ b/qml.qrc
@@ -121,5 +121,6 @@
         <file>components/StandardDialog.qml</file>
         <file>pages/Sign.qml</file>
         <file>components/DaemonManagerDialog.qml</file>
+        <file>components/StandardDialog.qml</file>
     </qresource>
 </RCC>

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -80,9 +80,8 @@ void DaemonManager::printOutput()
     QStringList strLines = QString(byteArray).split("\n");
 
     foreach (QString line, strLines){
-       // dConsole.append(line+"\n");
         emit daemonConsoleUpdated(line);
-       // qDebug() << "Daemon: " + line;
+        qDebug() << "Daemon: " + line;
     }
 }
 
@@ -92,9 +91,8 @@ void DaemonManager::printError()
     QStringList strLines = QString(byteArray).split("\n");
 
     foreach (QString line, strLines){
-       // dConsole.append(line+"\n");
         emit daemonConsoleUpdated(line);
-       // qDebug() << "Daemon ERROR: " + line;
+        qDebug() << "Daemon ERROR: " + line;
     }
 }
 
@@ -108,12 +106,6 @@ bool DaemonManager::running() const
     }
     return false;
 }
-
-QString DaemonManager::console() const
-{
-    return dConsole;
-}
-
 
 DaemonManager::DaemonManager(QObject *parent)
     : QObject(parent)

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -123,3 +123,8 @@ DaemonManager::DaemonManager(QObject *parent)
 
 }
 
+void DaemonManager::closing()
+{
+    qDebug() << __FUNCTION__;
+    stop();
+}

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -136,4 +136,8 @@ void DaemonManager::closing()
 {
     qDebug() << __FUNCTION__;
     stop();
+    // Wait for daemon to stop before exiting (max 10 secs)
+    if(initialized){
+        m_daemon->waitForFinished(10000);
+    }
 }

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -41,6 +41,7 @@ bool DaemonManager::start()
     QStringList arguments;
 
     m_daemon = new QProcess();
+    initialized = true;
 
     // Connect output slots
     connect (m_daemon, SIGNAL(readyReadStandardOutput()), this, SLOT(printOutput()));
@@ -61,7 +62,7 @@ bool DaemonManager::start()
 
 bool DaemonManager::stop()
 {
-    if(m_daemon){
+    if(initialized){
         qDebug() << "stopping daemon";
         m_daemon->terminate();
         // Wait until stopped. Max 10 seconds
@@ -80,7 +81,8 @@ void DaemonManager::printOutput()
 
     foreach (QString line, strLines){
        // dConsole.append(line+"\n");
-        qDebug() << "Daemon: " + line;
+        emit daemonConsoleUpdated(line);
+       // qDebug() << "Daemon: " + line;
     }
 }
 
@@ -91,13 +93,20 @@ void DaemonManager::printError()
 
     foreach (QString line, strLines){
        // dConsole.append(line+"\n");
-        qDebug() << "Daemon ERROR: " + line;
+        emit daemonConsoleUpdated(line);
+       // qDebug() << "Daemon ERROR: " + line;
     }
 }
 
 bool DaemonManager::running() const
 {
-    return m_daemon && m_daemon->state() > QProcess::NotRunning;
+    if(initialized){
+        qDebug() << m_daemon->state();
+        qDebug() << QProcess::NotRunning;
+
+        return m_daemon->state() > QProcess::NotRunning;
+    }
+    return false;
 }
 
 QString DaemonManager::console() const

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -36,6 +36,8 @@ bool DaemonManager::start()
 
     if(!started){
         qDebug() << "Daemon start error: " + m_daemon->errorString();
+    } else {
+        emit daemonStarted();
     }
 
     return started;
@@ -43,6 +45,15 @@ bool DaemonManager::start()
 
 bool DaemonManager::stop()
 {
+    if(m_daemon){
+        qDebug() << "stopping daemon";
+        m_daemon->terminate();
+        // Wait until stopped. Max 30 seconds
+        bool stopped = m_daemon->waitForFinished(30000);
+        if(stopped) emit daemonStopped();
+        return stopped;
+    }
+
     return true;
 }
 

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -1,0 +1,87 @@
+#include "DaemonManager.h"
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QDebug>
+#include <QUrl>
+#include <QtConcurrent/QtConcurrent>
+#include <QApplication>
+#include <QProcess>
+
+DaemonManager * DaemonManager::m_instance = nullptr;
+
+DaemonManager *DaemonManager::instance()
+{
+    if (!m_instance) {
+        m_instance = new DaemonManager;
+    }
+
+    return m_instance;
+}
+
+bool DaemonManager::start()
+{
+    QString        program = QApplication::applicationDirPath() + "/monerod";
+    qDebug() << "starting monerod " + program;
+    QStringList arguments;
+
+    m_daemon = new QProcess();
+
+    connect (m_daemon, SIGNAL(readyReadStandardOutput()), this, SLOT(printOutput()));
+    connect (m_daemon, SIGNAL(readyReadStandardError()), this, SLOT(printError()));
+
+
+    m_daemon->start(program);
+    bool started =  m_daemon->waitForStarted();
+
+    if(!started){
+        qDebug() << "Daemon start error: " + m_daemon->errorString();
+    }
+
+    return started;
+}
+
+bool DaemonManager::stop()
+{
+    return true;
+}
+
+void DaemonManager::printOutput()
+{
+    QByteArray byteArray = m_daemon->readAllStandardOutput();
+    QStringList strLines = QString(byteArray).split("\n");
+
+    foreach (QString line, strLines){
+       // dConsole.append(line+"\n");
+        qDebug() << "Daemon: " + line;
+    }
+}
+
+void DaemonManager::printError()
+{
+    QByteArray byteArray = m_daemon->readAllStandardError();
+    QStringList strLines = QString(byteArray).split("\n");
+
+    foreach (QString line, strLines){
+       // dConsole.append(line+"\n");
+        qDebug() << "Daemon ERROR: " + line;
+    }
+}
+
+bool DaemonManager::running() const
+{
+    return m_daemon && m_daemon->state() > QProcess::NotRunning;
+}
+
+QString DaemonManager::console() const
+{
+    return dConsole;
+}
+
+
+DaemonManager::DaemonManager(QObject *parent)
+    : QObject(parent)
+{
+
+}
+

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -21,8 +21,7 @@ public:
     Q_INVOKABLE bool running() const;
 
 signals:
-
-    void daemonStarted(const QProcess &d);
+    void daemonStarted();
     void daemonStopped();
 
 public slots:

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -1,0 +1,41 @@
+#ifndef DAEMONMANAGER_H
+#define DAEMONMANAGER_H
+
+#include <QObject>
+#include <QUrl>
+#include <QProcess>
+
+class DaemonManager : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    static DaemonManager * instance();
+
+    Q_INVOKABLE bool start();
+    Q_INVOKABLE bool stop();
+    Q_INVOKABLE QString console() const;
+
+    // return true if daemon process is started
+    Q_INVOKABLE bool running() const;
+
+signals:
+
+    void daemonStarted(const QProcess &d);
+    void daemonStopped();
+
+public slots:
+    void printOutput();
+    void printError();
+
+private:
+
+    explicit DaemonManager(QObject *parent = 0);
+    static DaemonManager * m_instance;
+    QProcess *m_daemon;
+    QString dConsole;
+
+};
+
+#endif // DAEMONMANAGER_H

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -15,7 +15,6 @@ public:
 
     Q_INVOKABLE bool start();
     Q_INVOKABLE bool stop();
-    Q_INVOKABLE QString console() const;
 
     // return true if daemon process is started
     Q_INVOKABLE bool running() const;
@@ -34,7 +33,6 @@ private:
     explicit DaemonManager(QObject *parent = 0);
     static DaemonManager * m_instance;
     QProcess *m_daemon;
-    QString dConsole;
     bool initialized = false;
 
 };

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -11,7 +11,7 @@ class DaemonManager : public QObject
 
 public:
 
-    static DaemonManager * instance(QStringList args);
+    static DaemonManager * instance(const QStringList *args);
 
     Q_INVOKABLE bool start();
     Q_INVOKABLE bool stop();
@@ -34,7 +34,7 @@ private:
 
     explicit DaemonManager(QObject *parent = 0);
     static DaemonManager * m_instance;
-    static QStringList clArgs;
+    static QStringList m_clArgs;
     QProcess *m_daemon;
     bool initialized = false;
 

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -23,6 +23,7 @@ public:
 signals:
     void daemonStarted();
     void daemonStopped();
+    void daemonConsoleUpdated(QString message);
 
 public slots:
     void printOutput();
@@ -34,6 +35,7 @@ private:
     static DaemonManager * m_instance;
     QProcess *m_daemon;
     QString dConsole;
+    bool initialized = false;
 
 };
 

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -11,7 +11,7 @@ class DaemonManager : public QObject
 
 public:
 
-    static DaemonManager * instance();
+    static DaemonManager * instance(QStringList args);
 
     Q_INVOKABLE bool start();
     Q_INVOKABLE bool stop();
@@ -32,6 +32,7 @@ private:
 
     explicit DaemonManager(QObject *parent = 0);
     static DaemonManager * m_instance;
+    static QStringList clArgs;
     QProcess *m_daemon;
     bool initialized = false;
 

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -27,6 +27,7 @@ signals:
 public slots:
     void printOutput();
     void printError();
+    void closing();
 
 private:
 

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -28,6 +28,7 @@ public slots:
     void printOutput();
     void printError();
     void closing();
+    void stateChanged(QProcess::ProcessState state);
 
 private:
 

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -88,13 +88,13 @@ Wallet::Status Wallet::status() const
     return static_cast<Status>(m_walletImpl->status());
 }
 
-Wallet::ConnectionStatus Wallet::connected()
+Wallet::ConnectionStatus Wallet::connected() const
 {
     // cache connection status
-    if(!m_initialized || m_connectionStatusTime.elapsed() / 1000 > m_connectionStatusTtl){
+    if (!m_initialized || m_connectionStatusTime.elapsed() / 1000 > m_connectionStatusTtl) {
         m_initialized = true;
         ConnectionStatus newStatus = static_cast<ConnectionStatus>(m_walletImpl->connected());
-        if(newStatus != m_connectionStatus) {
+        if (newStatus != m_connectionStatus) {
             m_connectionStatus = newStatus;
             emit connectionStatusChanged();
         }

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -87,9 +87,15 @@ Wallet::Status Wallet::status() const
     return static_cast<Status>(m_walletImpl->status());
 }
 
-Wallet::ConnectionStatus Wallet::connected() const
+Wallet::ConnectionStatus Wallet::connected()
 {
-    return static_cast<ConnectionStatus>(m_walletImpl->connected());
+    qDebug("Checking wallet connection status");
+    ConnectionStatus newStatus = static_cast<ConnectionStatus>(m_walletImpl->connected());
+    if(newStatus != m_connectionStatus) {
+        m_connectionStatus = newStatus;
+        emit connectionStatusChanged();
+    }
+    return newStatus;
 }
 
 bool Wallet::synchronized() const
@@ -422,6 +428,7 @@ Wallet::Wallet(Bitmonero::Wallet *w, QObject *parent)
 {
     m_history = new TransactionHistory(m_walletImpl->history(), this);
     m_walletImpl->setListener(new WalletListenerImpl(this));
+    m_connectionStatus = Wallet::ConnectionStatus_Disconnected;
 }
 
 Wallet::~Wallet()

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -90,11 +90,9 @@ Wallet::Status Wallet::status() const
 
 Wallet::ConnectionStatus Wallet::connected()
 {
-    qDebug("Checking wallet connection status");
-
     // cache connection status
-    if(m_connectionStatusTime.elapsed() / 1000 > m_connectionStatusTtl){
-        qDebug("connectionStatus query");
+    if(!m_initialized || m_connectionStatusTime.elapsed() / 1000 > m_connectionStatusTtl){
+        m_initialized = true;
         ConnectionStatus newStatus = static_cast<ConnectionStatus>(m_walletImpl->connected());
         if(newStatus != m_connectionStatus) {
             m_connectionStatus = newStatus;
@@ -442,6 +440,7 @@ Wallet::Wallet(Bitmonero::Wallet *w, QObject *parent)
     m_connectionStatusTime.restart();
     m_daemonBlockChainHeightTime.restart();
     m_daemonBlockChainTargetHeightTime.restart();
+    m_initialized = false;
 }
 
 Wallet::~Wallet()

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -220,6 +220,8 @@ private:
     mutable quint64 m_daemonBlockChainTargetHeight;
     int     m_daemonBlockChainTargetHeightTtl;
     ConnectionStatus m_connectionStatus;
+    int     m_connectionStatusTtl;
+    mutable QTime   m_connectionStatusTime;
 };
 
 

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -222,6 +222,7 @@ private:
     ConnectionStatus m_connectionStatus;
     int     m_connectionStatusTtl;
     mutable QTime   m_connectionStatusTime;
+    bool    m_initialized;
 };
 
 

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -63,7 +63,7 @@ public:
     Status status() const;
 
     //! returns whether the wallet is connected, and version status
-    ConnectionStatus connected();
+    ConnectionStatus connected() const;
 
     //! returns true if wallet was ever synchronized
     bool synchronized() const;
@@ -196,7 +196,7 @@ signals:
     // emitted when transaction is created async
     void transactionCreated(PendingTransaction * transaction, QString address, QString paymentId, quint32 mixinCount);
 
-    void connectionStatusChanged();
+    void connectionStatusChanged() const;
 
 private:
     Wallet(QObject * parent = nullptr);
@@ -219,10 +219,10 @@ private:
     mutable QTime   m_daemonBlockChainTargetHeightTime;
     mutable quint64 m_daemonBlockChainTargetHeight;
     int     m_daemonBlockChainTargetHeightTtl;
-    ConnectionStatus m_connectionStatus;
+    mutable ConnectionStatus m_connectionStatus;
     int     m_connectionStatusTtl;
     mutable QTime   m_connectionStatusTime;
-    bool    m_initialized;
+    mutable bool    m_initialized;
 };
 
 

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -63,7 +63,7 @@ public:
     Status status() const;
 
     //! returns whether the wallet is connected, and version status
-    ConnectionStatus connected() const;
+    ConnectionStatus connected();
 
     //! returns true if wallet was ever synchronized
     bool synchronized() const;
@@ -196,6 +196,8 @@ signals:
     // emitted when transaction is created async
     void transactionCreated(PendingTransaction * transaction, QString address, QString paymentId, quint32 mixinCount);
 
+    void connectionStatusChanged();
+
 private:
     Wallet(QObject * parent = nullptr);
     Wallet(Bitmonero::Wallet *w, QObject * parent = 0);
@@ -217,6 +219,7 @@ private:
     mutable QTime   m_daemonBlockChainTargetHeightTime;
     mutable quint64 m_daemonBlockChainTargetHeight;
     int     m_daemonBlockChainTargetHeightTtl;
+    ConnectionStatus m_connectionStatus;
 };
 
 


### PR DESCRIPTION
Start/stop daemon from GUI + random improvements.
Requires a monerod/monerod.exe in same folder as monero-core binary.
All cli arguments are passed to monerod. For example --data-dir

**Win32** 
Includes monerod 0.10.0.0
https://www.dropbox.com/s/ooigmm2kjxaja1t/monero-core-win32-daemon-manager-jaquee.zip?dl=1
**Note:** Sending funds is not is possible with included daemon. 

**OS X**
Includes monerod built from current master `17b6bd6`
https://www.dropbox.com/s/lqs9mpc50k20oq5/monero-core-osx-daemon-manager-jaquee.zip?dl=1




Fixes
https://github.com/monero-project/monero-core/issues/39
https://github.com/monero-project/monero-core/issues/165
