### PR TITLE
Remove useless black bar buttons

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -150,7 +150,7 @@ Rectangle {
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 2
-        anchors.topMargin: 30
+        anchors.topMargin: 0
         spacing: 0
 
 
@@ -169,12 +169,13 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: -5
                 anchors.left: parent.left
-                anchors.leftMargin: 20
+                anchors.leftMargin: 40
                 source: "images/moneroLogo2.png"
             }
 
             Grid {
                 anchors.verticalCenter: parent.verticalCenter
+                anchors.top: parent.top
                 anchors.right: parent.right
                 width: 256
                 columns: 3

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -31,28 +31,11 @@ import QtQuick.Window 2.0
 
 Rectangle {
     id: titleBar
-    height: 30
     color: "#000000"
-    y: -height
     property int mouseX: 0
-    property string title
     property bool containsMouse: false
-    property alias maximizeButtonVisible: maximizeButton.visible
     property alias basicButtonVisible: goToBasicVersionButton.visible
     signal goToBasicVersion(bool yes)
-
-    Text {
-        anchors.centerIn: parent
-        font.family: "Arial"
-        font.pixelSize: 15
-        font.letterSpacing: -1
-        color: "#FFFFFF"
-        text: titleBar.title
-    }
-    
-    Behavior on y {
-        NumberAnimation { duration: 100; easing.type: Easing.InQuad }
-    }
 
     Rectangle {
         id: goToBasicVersionButton
@@ -61,8 +44,10 @@ Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
-        width: height
+        anchors.right: parent.right
         color:  containsMouse || checked ? "#FFE00A" : "#000000"
+        width: parent.width
+        height: parent.height
 
         Image {
             anchors.centerIn: parent
@@ -76,98 +61,6 @@ Rectangle {
             onClicked: {
                 parent.checked = !parent.checked
                 titleBar.goToBasicVersion(parent.checked)
-            }
-        }
-    }
-    
-    Row {
-        id: row
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        
-        Rectangle {
-            property bool containsMouse: titleBar.mouseX >= x + row.x && titleBar.mouseX <= x + row.x + width && titleBar.containsMouse
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            width: height
-            color: containsMouse ? "#6B0072" : "#000000"
-            
-            Image {
-                anchors.centerIn: parent
-                source: "../images/helpIcon.png"
-            }
-            
-            MouseArea {
-                id: whatIsArea
-                anchors.fill: parent
-                onClicked: {
-
-                }
-            }
-        }
-        
-        Rectangle {
-            property bool containsMouse: titleBar.mouseX >= x + row.x && titleBar.mouseX <= x + row.x + width && titleBar.containsMouse
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            width: height
-            color: containsMouse ? "#3665B3" : "#000000"
-            
-            Image {
-                anchors.centerIn: parent
-                source: "../images/minimizeIcon.png"
-            }
-            
-            MouseArea {
-                id: minimizeArea
-                anchors.fill: parent
-                onClicked: {
-                    appWindow.visibility = Window.Minimized
-                }
-            }
-        }
-        
-        Rectangle {
-            id: maximizeButton
-            property bool containsMouse: titleBar.mouseX >= x + row.x && titleBar.mouseX <= x + row.x + width && titleBar.containsMouse
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            width: height
-            color: containsMouse ? "#FF6C3C" : "#000000"
-            
-            Image {
-                anchors.centerIn: parent
-                source: appWindow.visibility === Window.FullScreen ?  "../images/backToWindowIcon.png" :
-                                                                      "../images/maximizeIcon.png"
-
-            }
-            
-            MouseArea {
-                id: maximizeArea
-                anchors.fill: parent
-                onClicked: {
-                    appWindow.visibility = appWindow.visibility !== Window.FullScreen ? Window.FullScreen :
-                                                                                        Window.Windowed
-                }
-            }
-        }
-        
-        Rectangle {
-            property bool containsMouse: titleBar.mouseX >= x + row.x && titleBar.mouseX <= x + row.x + width && titleBar.containsMouse
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            width: height
-            color: containsMouse ? "#E04343" : "#000000"
-            
-            Image {
-                anchors.centerIn: parent
-                source: "../images/closeIcon.png"
-            }
-            
-            MouseArea {
-                anchors.fill: parent
-                onClicked: appWindow.close();
             }
         }
     }

--- a/main.qml
+++ b/main.qml
@@ -622,7 +622,7 @@ ApplicationWindow {
     width: rightPanelExpanded ? 1269 : 1269 - 300
     height: maxWindowHeight;
     color: "#FFFFFF"
-    flags: Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint
+    flags: Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint
     onWidthChanged: x -= 0
 
 
@@ -750,10 +750,7 @@ ApplicationWindow {
                 PropertyChanges { target: appWindow; width: 930; }
                 PropertyChanges { target: appWindow; height: 595; }
                 PropertyChanges { target: resizeArea; visible: false }
-                PropertyChanges { target: titleBar; maximizeButtonVisible: false }
                 PropertyChanges { target: frameArea; blocked: true }
-                PropertyChanges { target: titleBar; y: 0 }
-                PropertyChanges { target: titleBar; title: qsTr("Program setup wizard") + translationManager.emptyString }
             }, State {
                 name: "normal"
                 PropertyChanges { target: leftPanel; visible: true }
@@ -764,10 +761,7 @@ ApplicationWindow {
                 PropertyChanges { target: appWindow; width: rightPanelExpanded ? 1269 : 1269 - 300; }
                 PropertyChanges { target: appWindow; height: maxWindowHeight; }
                 PropertyChanges { target: resizeArea; visible: true }
-                PropertyChanges { target: titleBar; maximizeButtonVisible: true }
                 PropertyChanges { target: frameArea; blocked: false }
-                PropertyChanges { target: titleBar; y: 0 }
-                PropertyChanges { target: titleBar; title: qsTr("Monero") + translationManager.emptyString }
             }
         ]
 
@@ -821,11 +815,6 @@ ApplicationWindow {
             height: 30
             z: 1
             hoverEnabled: true
-            // Uncomment to enable 'auto-hidden' titlebar
-            /*
-            onEntered: if(!blocked) titleBar.y = 0
-            onExited: if(!blocked) titleBar.y = -titleBar.height
-            */
             propagateComposedEvents: true
             onPressed: mouse.accepted = false
             onReleased: mouse.accepted = false
@@ -839,11 +828,6 @@ ApplicationWindow {
                 target: appWindow
                 properties: "visibility"
                 value: Window.Windowed
-            }
-            PropertyAction {
-                target: titleBar
-                properties: "maximizeButtonVisible"
-                value: false
             }
             PropertyAction {
                 target: frameArea
@@ -933,11 +917,6 @@ ApplicationWindow {
                 properties: "blocked"
                 value: false
             }
-            PropertyAction {
-                target: titleBar
-                properties: "maximizeButtonVisible"
-                value: true
-            }
         }
 
         WizardMain {
@@ -1000,8 +979,10 @@ ApplicationWindow {
 
         TitleBar {
             id: titleBar
-            anchors.left: parent.left
-            anchors.right: parent.right
+            x: 0
+            y: 0
+            width: 30
+            height: 30
             onGoToBasicVersion: {
                 if (yes) {
                     // basicPanel.currentView = middlePanel.currentView
@@ -1009,24 +990,6 @@ ApplicationWindow {
                 } else {
                     // middlePanel.currentView = basicPanel.currentView
                     goToProAnimation.start()
-                }
-            }
-
-            MouseArea {
-                property var previousPosition
-                anchors.fill: parent
-                propagateComposedEvents: true
-                onPressed: previousPosition = globalCursor.getPosition()
-                onPositionChanged: {
-                    if (pressedButtons == Qt.LeftButton) {
-                        var pos = globalCursor.getPosition()
-                        var dx = pos.x - previousPosition.x
-                        var dy = pos.y - previousPosition.y
-
-                        appWindow.x += dx
-                        appWindow.y += dy
-                        previousPosition = pos
-                    }
                 }
             }
         }


### PR DESCRIPTION
Except the yellow layout change one, which is actually useful

In particular, the close button closed without saving the wallet
cache, contrary to what closing using the window manager close
button did. Which isn't nice if you want to keep your tx keys.
Also, the size change buttons don't work.

Also tweak the WM hints to make sure there's a close button
displayed on all platforms.