### PR TITLE
Do not allow non-ascii characters in path on windows. 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -110,12 +110,14 @@ int main(int argc, char *argv[])
 //  to save the wallet file (.keys, .bin), they have to be user-accessible for
 //  backups - I reckon we save that in My Documents\Monero Accounts\ on
 //  Windows, ~/Monero Accounts/ on nix / osx
-
+    bool isWindows = false;
 #ifdef Q_OS_WIN
+    isWindows = true;
     QStringList moneroAccountsRootDir = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
 #elif defined(Q_OS_UNIX)
     QStringList moneroAccountsRootDir = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
 #endif
+    engine.rootContext()->setContextProperty("isWindows", isWindows);
 
     if (!moneroAccountsRootDir.empty()) {
         QString moneroAccountsDir = moneroAccountsRootDir.at(0) + "/Monero/wallets";

--- a/wizard/WizardCreateWallet.qml
+++ b/wizard/WizardCreateWallet.qml
@@ -55,7 +55,7 @@ Item {
         settingsObject['words'] = uiItem.wordsTexttext
         settingsObject['wallet_path'] = uiItem.walletPath
         var walletFullPath = wizard.createWalletPath(uiItem.walletPath,uiItem.accountNameText);
-        return !wizard.walletExists(walletFullPath);
+        return wizard.walletPathValid(walletFullPath);
     }
 
     function checkNextButton() {

--- a/wizard/WizardMain.qml
+++ b/wizard/WizardMain.qml
@@ -141,12 +141,30 @@ Rectangle {
         return folder_path + "/" + account_name + "/" + account_name
     }
 
-    function walletExists(path){
-        if(walletManager.walletExists(path)){
-            walletExistsErrorDialog.open();
-            return true;
+    function walletPathValid(path){
+        if (walletManager.walletExists(path)) {
+            walletErrorDialog.text = qsTr("A wallet with same name already exists. Please change wallet name") + translationManager.emptyString;
+            walletErrorDialog.open();
+            return false;
         }
-        return false;
+
+        // Don't allow non ascii characters in path on windows platforms until supported by Wallet2
+        if (isWindows) {
+            if (!isAscii(path)) {
+                walletErrorDialog.text = qsTr("Non-ASCII characters are not allowed in wallet path or account name")  + translationManager.emptyString;
+                walletErrorDialog.open();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function isAscii(str){
+        for (var i = 0; i < str.length; i++) {
+            if (str.charCodeAt(i) > 127)
+                return false;
+        }
+        return true;
     }
 
     //! actually writes the wallet
@@ -197,9 +215,8 @@ Rectangle {
     }
 
     MessageDialog {
-        id: walletExistsErrorDialog
+        id: walletErrorDialog
         title: "Error"
-        text: qsTr("A wallet with same name already exists. Please change wallet name") + translationManager.emptyString
         onAccepted: {
         }
     }

--- a/wizard/WizardRecoveryWallet.qml
+++ b/wizard/WizardRecoveryWallet.qml
@@ -59,7 +59,7 @@ Item {
         var restoreHeight = parseInt(uiItem.restoreHeight);
         settingsObject['restore_height'] = isNaN(restoreHeight)? 0 : restoreHeight
         var walletFullPath = wizard.createWalletPath(uiItem.walletPath,uiItem.accountNameText);
-        if(wizard.walletExists(walletFullPath)){
+        if(!wizard.walletPathValid(walletFullPath)){
            return false
         }
         return recoveryWallet(settingsObject)


### PR DESCRIPTION
Until https://github.com/monero-project/monero-core/issues/199 and https://github.com/monero-project/monero/issues/1390 is fixed in Wallet2 we can't allow non-ascii characters i path. 