### PR TITLE
win32: use static boost

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -59,7 +59,7 @@ elif [ "$platform" == "mingw64" ]; then
 elif [ "$platform" == "mingw32" ]; then
     # Do something under Windows NT platform
     echo "Configuring build for MINGW32.."
-    cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D STATIC=ON -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
+    cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
     make_exec="mingw32-make"
 else
     echo "Unsupported platform: $platform"
@@ -83,7 +83,7 @@ if [ "$platform" != "linux" ]; then
     pushd $MONERO_DIR/build/release/external/unbound
     # no need to make, it was already built as dependency for libwallet
     # make -j$CPU_CORE_COUNT
-    make install -j$CPU_CORE_COUNT
+    $make_exec install -j$CPU_CORE_COUNT
     popd
 fi
 

--- a/monero-core.pro
+++ b/monero-core.pro
@@ -76,6 +76,9 @@ win32 {
         MSYS_PATH=c:/msys32/mingw32
     }
 
+    # boost root path
+    BOOST_PATH=/c/Qt/Qt5.7.0/Tools/mingw530_32/boost
+
     !contains(QMAKE_TARGET.arch, x86_64) {
         message("Target is 32bit")
         ## Windows x86 (32bit) specific build here
@@ -87,17 +90,18 @@ win32 {
     }
 
     LIBS+=-L$$MSYS_PATH/lib
+    LIBS+=-L$$BOOST_PATH/lib
 
     LIBS+= \
         -Wl,-Bstatic \
-        -lboost_serialization-mt \
-        -lboost_thread-mt \
-        -lboost_system-mt \
-        -lboost_date_time-mt \
-        -lboost_filesystem-mt \
-        -lboost_regex-mt \
-        -lboost_chrono-mt \
-        -lboost_program_options-mt \
+        -lboost_serialization-mt-s \
+        -lboost_thread-mt-s \
+        -lboost_system-mt-s \
+        -lboost_date_time-mt-s \
+        -lboost_filesystem-mt-s \
+        -lboost_regex-mt-s \
+        -lboost_chrono-mt-s \
+        -lboost_program_options-mt-s \
         -lssl \
         -lcrypto \
         -Wl,-Bdynamic \


### PR DESCRIPTION
boost on build machine is built with Qt's mingw toolchain

