### PR TITLE
Remove link to Address Book from Send page

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -194,7 +194,7 @@ Rectangle {
         fontSize: 14
         textFormat: Text.RichText
         text: qsTr("<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style>\
-                    Address <font size='2'>  ( Type in  or select from </font> <a href='#'>Address</a><font size='2'> book )</font>")
+                    Address")
               + translationManager.emptyString
 
         onLinkActivated: appWindow.showPageRequest("AddressBook")


### PR DESCRIPTION
GUI seems releasable without Address Book functionality. 

This PR proposes removing the Address Book link for the initial GUI release, with a goal to reimplement it later when functionality is complete.

See #242 