### PR TITLE
No left margin for button on Verify Payment page

### DIFF
--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -207,7 +207,6 @@ Rectangle {
             id: checkButton
             anchors.left: parent.left
             anchors.top: txKeyRow.bottom
-            anchors.leftMargin: 17
             anchors.topMargin: 17
             width: 60
             text: qsTr("CHECK") + translationManager.emptyString


### PR DESCRIPTION
This brings the "Check" button on the Verify Payment page into alignment with the rest of the text.