### PR TITLE
Remove fee multiplier info from low/high slider

### DIFF
--- a/components/PrivacyLevelSmall.qml
+++ b/components/PrivacyLevelSmall.qml
@@ -99,7 +99,7 @@ Item {
             font.bold: true
             color: "#000000"
             x: row.x + (row.positions[0] !== undefined ? row.positions[0].currentX - 3 : 0) - width
-            text: qsTr("LOW (x1 fee)") + translationManager.emptyString
+            text: qsTr("LOW") + translationManager.emptyString
         }
 
         Text {
@@ -110,7 +110,7 @@ Item {
             font.bold: true
             color: "#000000"
             x: row.x + (row.positions[4] !== undefined ? row.positions[4].currentX - 3 : 0) - width
-            text: qsTr("MEDIUM (x20 fee)") + translationManager.emptyString
+            text: qsTr("MEDIUM") + translationManager.emptyString
         }
 
         Text {
@@ -121,7 +121,7 @@ Item {
             font.bold: true
             color: "#000000"
             x: row.x + (row.positions[13] !== undefined ? row.positions[13].currentX - 3 : 0) - width
-            text: qsTr("HIGH (x166 fee)") + translationManager.emptyString
+            text: qsTr("HIGH") + translationManager.emptyString
         }
 
         MouseArea {

--- a/components/TickDelegate.qml
+++ b/components/TickDelegate.qml
@@ -52,9 +52,9 @@ Item {
             font.pixelSize: 12
             color: "#4A4949"
             text: {
-                if(currentIndex === 0) return qsTr("LOW (x1 fee)") + translationManager.emptyString
-                if(currentIndex === 3) return qsTr("MEDIUM (x20 fee)") + translationManager.emptyString
-                if(currentIndex === 13) return qsTr("HIGH (x166 fee)") + translationManager.emptyString
+                if(currentIndex === 0) return qsTr("LOW") + translationManager.emptyString
+                if(currentIndex === 3) return qsTr("MEDIUM") + translationManager.emptyString
+                if(currentIndex === 13) return qsTr("HIGH") + translationManager.emptyString
                 return ""
             }
         }


### PR DESCRIPTION
This was a braino on my part, this is only applicable for the
list based low/high selector.