### PR TITLE
Improved field descriptions on Send page

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -194,7 +194,7 @@ Rectangle {
         fontSize: 14
         textFormat: Text.RichText
         text: qsTr("<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style>\
-                    Address <font size='2'>  ( Type in  or select from </font> <a href='#'>Address</a><font size='2'> book )</font>")
+                    Address <font size='2'>  ( Paste in or select from </font> <a href='#'>Address book</a><font size='2'> )</font>")
               + translationManager.emptyString
 
         onLinkActivated: appWindow.showPageRequest("AddressBook")
@@ -246,7 +246,7 @@ Rectangle {
         anchors.rightMargin: 17
         anchors.topMargin: 17
         fontSize: 14
-        text: qsTr("Description <font size='2'>( An optional description that will be saved to the local address book if entered )</font>")
+        text: qsTr("Description <font size='2'>( Optional - saved to local wallet history )</font>")
               + translationManager.emptyString
     }
 


### PR DESCRIPTION
1. "Paste" vs. "Type" in address.

2. Description is not saved to local address book but to local history page.