### PR TITLE
Improved description of Verify Payments page

### DIFF
--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -91,11 +91,11 @@ Rectangle {
                     wrapMode: Text.Wrap
                 }
                 Text {
-                    text: qsTr(" - the recipient address,") + translationManager.emptyString
+                    text: qsTr(" - the recipient address") + translationManager.emptyString
                     wrapMode: Text.Wrap
                 }
                 Text {
-                    text: qsTr(" - the transaction ID,") + translationManager.emptyString
+                    text: qsTr(" - the transaction ID") + translationManager.emptyString
                     wrapMode: Text.Wrap
                 }
                 Text {
@@ -103,7 +103,7 @@ Rectangle {
                     wrapMode: Text.Wrap
                 }
                 Text {
-                    text: qsTr("If a payment had several transactions then each must must be checked and the results combined") + translationManager.emptyString
+                    text: qsTr("If a payment had several transactions then each must must be checked and the results combined.") + translationManager.emptyString
                     wrapMode: Text.Wrap
                     Layout.fillWidth: true;
                 }

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -87,7 +87,7 @@ Rectangle {
             ColumnLayout {
 
                 Text {
-                    text: qsTr("You can verify that a third party made a payment by supplying:") + translationManager.emptyString
+                    text: qsTr("Verify that a third party made a payment by supplying:") + translationManager.emptyString
                     wrapMode: Text.Wrap
                 }
                 Text {
@@ -99,11 +99,11 @@ Rectangle {
                     wrapMode: Text.Wrap
                 }
                 Text {
-                    text: qsTr(" - the tx secret key supplied by the sender") + translationManager.emptyString
+                    text: qsTr(" - the secret transaction key supplied by the sender") + translationManager.emptyString
                     wrapMode: Text.Wrap
                 }
                 Text {
-                    text: qsTr("If a payment was made up of several transactions, each transaction must be checked, and the results added") + translationManager.emptyString
+                    text: qsTr("If a payment had several transactions then each must must be checked and the results combined") + translationManager.emptyString
                     wrapMode: Text.Wrap
                     Layout.fillWidth: true;
                 }
@@ -154,7 +154,7 @@ Rectangle {
 
                 id: txIdLine
                 fontSize: mainLayout.lineEditFontSize
-                placeholderText: qsTr("Transaction ID here") + translationManager.emptyString
+                placeholderText: qsTr("Paste tx ID") + translationManager.emptyString
                 readOnly: false
                 width: mainLayout.editWidth
                 Layout.fillWidth: true
@@ -186,7 +186,7 @@ Rectangle {
             LineEdit {
                 id: txKeyLine
                 fontSize: mainLayout.lineEditFontSize
-                placeholderText: qsTr("Transaction key here") + translationManager.emptyString;
+                placeholderText: qsTr("Paste tx key") + translationManager.emptyString;
                 readOnly: false
 
                 width: mainLayout.editWidth


### PR DESCRIPTION
Shortened/simplified some text.

Changed placeholders from the word "transaction" to the shorthand "tx". Since the user already sees the word "transaction" to the left of the field, they understand that they mean the same thing, which is important since the History page, where most will get their tx IDs and tx keys, use "tx" instead of "transaction".

Also the placeholders were changed from "Transaction ID here" to "Paste transaction ID". The text to the left of the field already is an indicator of what the box is for, so the placeholder instead acts as an action for the user to take (paste!).