### PR TITLE
Simplify text on wizard Option page

### DIFF
--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -137,7 +137,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 width:page.buttonSize
                 wrapMode: Text.WordWrap
-                text: qsTr("This is my first time, I want to create a new account") + translationManager.emptyString
+                text: qsTr("Create a new wallet") + translationManager.emptyString
             }
         }
 
@@ -174,7 +174,7 @@ Item {
                 font.pixelSize: 16
                 color: "#4A4949"
                 horizontalAlignment: Text.AlignHCenter
-                text: qsTr("I want to recover my account from my 25 word seed") + translationManager.emptyString
+                text: qsTr("Recover wallet from 25 word mnemonic seed") + translationManager.emptyString
                 width:page.buttonSize
                 wrapMode: Text.WordWrap
             }
@@ -213,7 +213,7 @@ Item {
                 font.pixelSize: 16
                 color: "#4A4949"
                 horizontalAlignment: Text.AlignHCenter
-                text: qsTr("I want to open a wallet from file") + translationManager.emptyString
+                text: qsTr("Open a wallet from file") + translationManager.emptyString
                 width:page.buttonSize
                 wrapMode: Text.WordWrap
             }
@@ -248,7 +248,7 @@ Item {
 
                 color: "#4A4646"
                 wrapMode: Text.Wrap
-                text: qsTr("Please setup daemon address below.")
+                text: qsTr("Custom daemon address (optional)")
                                   + translationManager.emptyString
             }
 


### PR DESCRIPTION
Two fixes: 

(1) Removed first-person text. "I want to create a wallet" becomes "Create a wallet". The first person perspective wasn't helping as much as it was getting in the way of the user. It takes a long time to read the phrase "This is my first time, I want to create a new wallet" vs. the phrase "Create a new wallet". I think the original intent was to make the wizard more friendly for newbies but it really wasn't achieving that effect. New people are just going to click on "Create a new wallet" anyways, and there are plenty of people who will want to create a new wallet, but for whom it won't be their "first time".

(2) Normalized the terminology. The first two options (create / restore from seed) were calling wallets "accounts" while the third option (open file) was calling them wallets. So now they all say "wallets".

Here's the original page

![screen shot 2016-12-17 at 5 33 32 pm](https://cloud.githubusercontent.com/assets/21302237/21290314/8a85309e-c483-11e6-9509-a5b6d02a268d.png)

Here's the new page
![option-wizard](https://cloud.githubusercontent.com/assets/21302237/21290317/9891927c-c483-11e6-9d47-208e409f4582.png)

