### PR TITLE
Tab text: change Verify Payment to Check Payment

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -365,7 +365,7 @@ Rectangle {
                 id: txkeyButton
                 anchors.left: parent.left
                 anchors.right: parent.right
-                text: qsTr("Verify payment") + translationManager.emptyString
+                text: qsTr("Check payment") + translationManager.emptyString
                 symbol: qsTr("K") + translationManager.emptyString
                 dotColor: "#AAFFBB"
                 under: advancedButton


### PR DESCRIPTION
Now that we have an Advanced section of the left menu, Verify Payment and Sign/Verify are now next to each other. They sound the same. This PR changes the Verify Payment tab to Check Payment to better differentiate the two, which works well since the button inside Verify Payment is labeled "Check" anyways.