### PR TITLE
Adjectives or nouns for Languages

### DIFF
--- a/lang/languages.xml
+++ b/lang/languages.xml
@@ -11,15 +11,14 @@ List of available languages for your wallet's seed:
 5 : Russian
 6 : Japanese
 -->
-        <language display_name="US English" locale="en_US" wallet_language="English" flag="/lang/flags/usa.png" qs="none"/>
-        <language display_name="UK English" locale="en_GB" wallet_language="English" flag="/lang/flags/uk.png" qs="none"/>
-        <language display_name="Russia"     locale="ru_RU" wallet_language="Russian" flag="/lang/flags/russia.png" qs="none"/>
-        <language display_name="RPA"        locale="en_SA" wallet_language="English" flag="/lang/flags/rpa.png" qs="none"/>
-        <language display_name="Palestine"  locale="ar_PS" wallet_language="English" flag="/lang/flags/palestine.png" qs="none"/>
-        <language display_name="India"      locale="hi_IN" wallet_language="English" flag="/lang/flags/india.png" qs="none"/>
-        <language display_name="Italiano"      locale="it_IT" wallet_language="Italian" flag="/lang/flags/italy.png" qs="none"/>
+        <language display_name="English (US)" locale="en_US" wallet_language="English" flag="/lang/flags/usa.png" qs="none"/>
+        <language display_name="English (UK)" locale="en_GB" wallet_language="English" flag="/lang/flags/uk.png" qs="none"/>
+        <language display_name="Russian"     locale="ru_RU" wallet_language="Russian" flag="/lang/flags/russia.png" qs="none"/>
+        <language display_name="English (RPA)"        locale="en_SA" wallet_language="English" flag="/lang/flags/rpa.png" qs="none"/>
+        <language display_name="Arabic (Palestine)"  locale="ar_PS" wallet_language="English" flag="/lang/flags/palestine.png" qs="none"/>
+        <language display_name="Hindi"      locale="hi_IN" wallet_language="English" flag="/lang/flags/india.png" qs="none"/>
+        <language display_name="Italian"      locale="it_IT" wallet_language="Italian" flag="/lang/flags/italy.png" qs="none"/>
         <language display_name="German"     locale="de_DE" wallet_language="German"  flag="/lang/flags/german.png" qs="none"/>
-        <language display_name="China"      locale="zh_CN" wallet_language="English" flag="/lang/flags/china.png" qs="none"/>
-        <language display_name="Brazil"     locale="pt_BR" wallet_language="Portuguese" flag="/lang/flags/brazil.png" qs="none"/>
-        <language display_name="Bangladesh" locale="en_US" wallet_language="English" flag="/lang/flags/bangladesh.png" qs="none"/>
+        <language display_name="Mandarin"      locale="zh_CN" wallet_language="English" flag="/lang/flags/china.png" qs="none"/>
+        <language display_name="Portuguese (Brazil)"     locale="pt_BR" wallet_language="Portuguese" flag="/lang/flags/brazil.png" qs="none"/>
 </languages>


### PR DESCRIPTION
I thought it was agreed some time back that the language names would be adjectives in their own languages, but it does not seem that this has been effected. In the meantime, English adjectives can suffice. What does *not* make sense is a mix of adjectives and nouns. "Choose your language: English, Russia, or Brasil" sounds potato.