### PR TITLE
Improved copy for GUI Wizard

### DIFF
--- a/wizard/WizardCreateWallet.qml
+++ b/wizard/WizardCreateWallet.qml
@@ -96,8 +96,8 @@ Item {
 
     WizardManageWalletUI {
         id: uiItem
-        titleText: qsTr("A new wallet has been created for you") + translationManager.emptyString
-        wordsTextTitle: qsTr("This is the 25 word mnemonic for your wallet") + translationManager.emptyString
+        titleText: qsTr("Give your new wallet a name") + translationManager.emptyString
+        wordsTextTitle: qsTr("Here is your wallet's 25 word mnemonic seed") + translationManager.emptyString
         wordsTextItem.clipboardButtonVisible: true
         wordsTextItem.tipTextVisible: true
         wordsTextItem.memoTextReadOnly: true

--- a/wizard/WizardFinish.qml
+++ b/wizard/WizardFinish.qml
@@ -52,8 +52,8 @@ Item {
 
         return "<table>"
             + trStart + qsTr("Language") + trMiddle + wizard.settings["language"] + trEnd
-            + trStart + qsTr("Account name") + trMiddle + wizard.settings["account_name"] + trEnd
-            + trStart + qsTr("Seed") + trMiddle + wizard.settings["wallet"].seed + trEnd
+            + trStart + qsTr("Wallet name") + trMiddle + wizard.settings["account_name"] + trEnd
+            + trStart + qsTr("Backup seed") + trMiddle + wizard.settings["wallet"].seed + trEnd
             + trStart + qsTr("Wallet path") + trMiddle + wizard.settings["wallet_path"] + trEnd
             // + trStart + qsTr("Auto donations") + trMiddle + autoDonationText + trEnd
             // + (autoDonationEnabled
@@ -70,7 +70,7 @@ Item {
     }
 
     function updateSettingsSummary() {
-        settingsText.text = qsTr("An overview of your Monero configuration is below:") + translationManager.emptyString
+        settingsText.text = qsTr("New wallet details:") + translationManager.emptyString
                             + "<br>"
                             + buildSettingsString();
     }

--- a/wizard/WizardManageWalletUI.qml
+++ b/wizard/WizardManageWalletUI.qml
@@ -104,7 +104,7 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             //renderType: Text.NativeRendering
             color: "#4A4646"
-            text: qsTr("This is the name of your wallet. You can change it to a different name if you’d like:") + translationManager.emptyString
+            text: qsTr("or use the name suggested below:") + translationManager.emptyString
         }
     }
 
@@ -175,7 +175,7 @@ Item {
         anchors.top: memoTextItem.bottom
         width: 250
         anchors.topMargin: 20
-        placeholderText: qsTr("Restore height")
+        placeholderText: qsTr("Restore height (optional)")
         Layout.alignment: Qt.AlignCenter
         validator: IntValidator {
             bottom:0

--- a/wizard/WizardMemoTextInput.qml
+++ b/wizard/WizardMemoTextInput.qml
@@ -73,7 +73,7 @@ Column {
                 font.pixelSize: 15
                 color: "#4A4646"
                 wrapMode: Text.Wrap
-                text: qsTr("It is very important to write it down as this is the only backup you will need for your wallet.")
+                text: qsTr("This seed is VERY important to write down and keep secret. It is all you need to backup and restore your wallet.")
                     + translationManager.emptyString
             }
         }

--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -174,7 +174,7 @@ Item {
                 font.pixelSize: 16
                 color: "#4A4949"
                 horizontalAlignment: Text.AlignHCenter
-                text: qsTr("Recover wallet from 25 word mnemonic seed") + translationManager.emptyString
+                text: qsTr("Restore wallet from 25 word mnemonic seed") + translationManager.emptyString
                 width:page.buttonSize
                 wrapMode: Text.WordWrap
             }

--- a/wizard/WizardPassword.qml
+++ b/wizard/WizardPassword.qml
@@ -50,9 +50,9 @@ Item {
         handlePassword();
 
         if (wizard.currentPath === "create_wallet") {
-           passwordPage.titleText = qsTr("Now that your wallet has been created, please set a password for the wallet") + translationManager.emptyString
+           passwordPage.titleText = qsTr("Give your wallet a password") + translationManager.emptyString
         } else {
-           passwordPage.titleText = qsTr("Now that your wallet has been restored, please set a password for the wallet") + translationManager.emptyString
+           passwordPage.titleText = qsTr("Give your wallet a password") + translationManager.emptyString
         }
 
         passwordItem.focus = true;
@@ -148,8 +148,8 @@ Item {
             //renderType: Text.NativeRendering
             color: "#4A4646"
             horizontalAlignment: Text.AlignHCenter
-            text: qsTr("Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given<br/><br/>
-                        Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.")
+            text: qsTr("Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.<br/><br/>
+                        Enter a secure password (using letters, numbers, and/or symbols):")
                     + translationManager.emptyString
         }
     }

--- a/wizard/WizardRecoveryWallet.qml
+++ b/wizard/WizardRecoveryWallet.qml
@@ -89,8 +89,8 @@ Item {
     WizardManageWalletUI {
         id: uiItem
         accountNameText: defaultAccountName
-        titleText: qsTr("We're ready to recover your account") + translationManager.emptyString
-        wordsTextTitle: qsTr("Please enter your 25 word private key") + translationManager.emptyString
+        titleText: qsTr("Give your restored wallet a name") + translationManager.emptyString
+        wordsTextTitle: qsTr("Enter your 25 word mnemonic seed:") + translationManager.emptyString
         wordsTextItem.clipboardButtonVisible: false
         wordsTextItem.tipTextVisible: false
         wordsTextItem.memoTextReadOnly: false


### PR DESCRIPTION
Multiple edits for copy on Create/Restore wallet wizard. Most simplified and shortened the existing text, others clarified what was a bit confusing ("enter your 25 word private key"), while others normalized more terminology (no longer calling wallets "accounts"). 

Probably the biggest change was to the titles of the pages. The previous titles tried to lead the user through the process ("A new wallet has been created for you"), but this often served to detract from the purpose of the page, for example the page "A new wallet has been created for you" was the page where the user was supposed to give their wallet a name. Now all the titles are simple and uniform ("Give your wallet a name" - "Give your wallet a password") and any necessary details were added below the titles.

The main edits can be seen below:

**Create wallet page**

![new-wallet-name](https://cloud.githubusercontent.com/assets/21302237/21379671/c8e9d460-c71d-11e6-905b-aebdcddfb9ce.png)

**Restore wallet page**

![restored-wallet-name](https://cloud.githubusercontent.com/assets/21302237/21379680/d8247b6a-c71d-11e6-83a9-16fdf06beb40.png)

**Set password page**

![set-password](https://cloud.githubusercontent.com/assets/21302237/21379683/df4baf1c-c71d-11e6-9937-d0e3f8edb2f1.png)

**Summary page**

![finalpage](https://cloud.githubusercontent.com/assets/21302237/21379693/e6d152c8-c71d-11e6-9e56-4911cd5220d0.png)

The only edit I wish I could do, but am unable due to lack of technical proficiency is to center the titles. "Give your wallet a name" and the rest of the titles should be aligned dead-center, but are currently off to the side. An Issue for this could be created in the future.

