### PR TITLE
optional static build on linux/mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 
 BUILD_TYPE=$1
+# default build type
 if [ -z $BUILD_TYPE ]; then
-    BUILD_TYPE=Release
+    BUILD_TYPE=release
+fi
+
+if [ "$BUILD_TYPE" == "release" ]; then
+    echo "Building release"
+    CONFIG="CONFIG+=release";
+    BIN_PATH=release/bin
+elif [ "$BUILD_TYPE" == "release-static" ]; then
+    echo "Building release-static"
+	CONFIG="CONFIG+=release static";
+    BIN_PATH=release/bin
+elif [ "$BUILD_TYPE" == "debug" ]; then
+    echo "Building debug"
+	CONFIG="CONFIG+=debug"
+    BIN_PATH=debug/bin
+else
+    echo "Valid build types are release, release-static and debug"
+    exit 1;
 fi
 
 
@@ -22,13 +40,6 @@ make -C src/zxcvbn-c
 
 if [ ! -d build ]; then mkdir build; fi
 
-if [ "$BUILD_TYPE" == "Release" ]; then
-	CONFIG="CONFIG+=release";
-  BIN_PATH=release/bin
-else
-	CONFIG="CONFIG+=debug"
-  BIN_PATH=debug/bin
-fi
 
 # Platform indepenent settings
 platform=$(get_platform)

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -129,7 +129,10 @@ win32 {
 }
 
 linux {
-    LIBS+= -Wl,-Bstatic
+    CONFIG(static) {
+        message("using static libraries")
+        LIBS+= -Wl,-Bstatic    
+    }
     LIBS+= \
         -lboost_serialization \
         -lboost_thread \
@@ -154,6 +157,11 @@ linux {
 }
 
 macx {
+    # mixing static and shared libs are not supported on mac
+    # CONFIG(static) {
+    #     message("using static libraries")
+    #     LIBS+= -Wl,-Bstatic
+    # }
     LIBS+= \
         -L/usr/local/lib \
         -L/usr/local/opt/openssl/lib \


### PR DESCRIPTION
fixes https://github.com/monero-project/monero-core/issues/58

@fluffypony @danrmiller
update buildbots from `./build.sh Release `-> `./build.sh release-static` when this is merged. 