### PR TITLE
Better use of emphasis in Wizard

### DIFF
--- a/wizard/WizardMemoTextInput.qml
+++ b/wizard/WizardMemoTextInput.qml
@@ -73,7 +73,7 @@ Column {
                 font.pixelSize: 15
                 color: "#4A4646"
                 wrapMode: Text.Wrap
-                text: qsTr("This seed is VERY important to write down and keep secret. It is all you need to backup and restore your wallet.")
+                text: qsTr("This seed is <b>very</b> important to write down and keep secret. It is all you need to backup and restore your wallet.")
                     + translationManager.emptyString
             }
         }

--- a/wizard/WizardPassword.qml
+++ b/wizard/WizardPassword.qml
@@ -149,7 +149,7 @@ Item {
             color: "#4A4646"
             horizontalAlignment: Text.AlignHCenter
             text: qsTr("Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.<br/><br/>
-                        Enter a secure password (using letters, numbers, and/or symbols):")
+                        <b>Enter a strong password</b> (using letters, numbers, and/or symbols):")
                     + translationManager.emptyString
         }
     }


### PR DESCRIPTION
Removed yelly uppercase letters ("VERY") and added bold instead to both mnemonic seed box ("very") and password page ("Enter a strong password") for better overall emphasis. Changed "Enter a secure password" to "Enter a strong password" since it seems a better descriptor overall - i.e. a strong password makes the wallet secure.