### PR TITLE
wizard: store settings before opening from file

### DIFF
--- a/wizard/WizardMain.qml
+++ b/wizard/WizardMain.qml
@@ -105,25 +105,19 @@ Rectangle {
 
     function openCreateWalletPage() {
         print ("show create wallet page");
-        pages[currentPage].opacity = 0;
-        createWalletPage.opacity = 1
         currentPath = "create_wallet"
-        pages = paths[currentPath]
-        currentPage = pages.indexOf(createWalletPage)
         createWalletPage.createWallet(settings)
         wizard.nextButton.visible = true
-        createWalletPage.onPageOpened(settings);
+        // goto next page
+        switchPage(true);
     }
 
     function openRecoveryWalletPage() {
         print ("show recovery wallet page");
-        pages[currentPage].opacity = 0
-        recoveryWalletPage.opacity = 1
         currentPath = "recovery_wallet"
-        pages = paths[currentPath]
-        currentPage = pages.indexOf(recoveryWalletPage)
         wizard.nextButton.visible = true
-        recoveryWalletPage.onPageOpened(settings);
+        // goto next page
+        switchPage(true);
     }
 
     function openOpenWalletPage() {
@@ -132,8 +126,8 @@ Rectangle {
             settings.wallet.destroy();
             delete wizard.settings['wallet'];
         }
-
-         wizard.openWalletFromFileClicked();
+        optionsPage.onPageClosed(settings)
+        wizard.openWalletFromFileClicked();
     }
 
     function createWalletPath(folder_path,account_name){

--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -40,6 +40,17 @@ Item {
     visible: false
     property var buttonSize: 190
 
+    function onPageClosed() {
+        // Save settings used in open from file.
+        // other wizard settings are saved on last page in applySettings()
+        appWindow.persistentSettings.testnet = wizard.settings["testnet"]
+        appWindow.persistentSettings.daemon_address = wizard.settings["daemon_address"]
+        appWindow.persistentSettings.language = wizard.settings.language
+        appWindow.persistentSettings.locale   = wizard.settings.locale
+
+        return true;
+    }
+
     function saveDaemonAddress() {
         wizard.settings["daemon_address"] = daemonAddress.text
         wizard.settings["testnet"] = testNet.checked
@@ -261,7 +272,12 @@ Item {
                     Layout.alignment: Qt.AlignCenter
                     width: 200
                     fontSize: 14
-                    text: testNet.checked ? d.daemonAddressTestnet : d.daemonAddressMainnet
+                    text: {
+                        if(appWindow.persistentSettings.daemon_address)
+                            return appWindow.persistentSettings.daemon_address;
+                        return testNet.checked ? d.daemonAddressTestnet : d.daemonAddressMainnet
+                    }
+
                 }
 
                 CheckBox {
@@ -274,7 +290,7 @@ Item {
                     fontSize: 16
                     checkedIcon: "../images/checkedVioletIcon.png"
                     uncheckedIcon: "../images/uncheckedIcon.png"
-                    checked: false
+                    checked: appWindow.persistentSettings.testnet;
                 }
             }
         }


### PR DESCRIPTION
Settings are only saved on last wizard page. When opening wallet form file the wallet skips the last pages in wizard and therefore misses language, daemon_address and testnet settings. 

Fixes #381
and probably https://github.com/monero-project/monero-core/issues/246 (not tested)


This PR also makes testnet and daemon address settings persistent between wallets. 