### PR TITLE
Add QrCode scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ Packaging for your favorite distribution would be a welcome contribution!
 
   - For Ubuntu 16.04 i386
 
-	`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs`
+	`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs libzbar-dev`
 
   - For Ubuntu 16.04 x64
 
-     `sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects`
+     `sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects libzbar-dev`
 
   - For Linux Mint 18 "Sarah" - Cinnamon (64-bit)
 
-     `sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects`
+     `sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects libzbar-dev`
 
 6. Build the GUI.
 

--- a/components/QRCodeScanner.qml
+++ b/components/QRCodeScanner.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.0
+import QtMultimedia 5.4
+import QtQuick.Dialogs 1.2
+import moneroComponents.QRCodeScanner 1.0
+
+Rectangle {
+    id : root
+
+    x: 0
+    y: 0
+    z: parent.z+1
+    width: parent.width 
+    height: parent.height
+
+    visible: false
+    color: "black"
+    state: "Stopped"
+
+    signal qrcode_decoded(string address, string payment_id, string amount, string tx_description, string recipient_name)
+
+    states: [
+        State {
+            name: "PhotoCapture"
+            StateChangeScript {
+                script: {
+		    root.visible = true
+                    camera.captureMode = Camera.CaptureStillImage
+                    camera.start()
+                    finder.enabled = true 
+                }
+            }
+        },
+        State {
+            name: "Stopped"
+            StateChangeScript {
+                script: {
+                    camera.stop()
+		    root.visible = false
+                    finder.enabled = false 
+                }
+            }
+        }
+    ]
+
+    Camera {
+        id: camera
+        objectName: "qrCameraQML"
+        captureMode: Camera.CaptureStillImage
+
+        focus {
+            focusMode: Camera.FocusContinuous
+        }
+    }
+    QRCodeScanner {
+        id : finder
+        objectName: "QrFinder"
+        onDecoded : {
+            root.qrcode_decoded(address, payment_id, amount, tx_description, recipient_name)
+            root.state = "Stopped"
+	}
+        onNotifyError : {
+            if( warning )
+                messageDialog.icon = StandardIcon.Critical
+            else { 
+                messageDialog.icon = StandardIcon.Warning
+                root.state = "Stopped"
+            }
+            messageDialog.text = error
+            messageDialog.visible = true
+        }
+    }
+
+    VideoOutput {
+        id: viewfinder
+        visible: root.state == "PhotoCapture"
+
+        x: 0
+        y: 0
+        z: parent.z+1
+        width: parent.width 
+        height: parent.height
+
+        source: camera
+        autoOrientation: true
+
+        MouseArea {
+            anchors.fill: parent
+            propagateComposedEvents: true
+            onPressAndHold: {
+                if (camera.lockStatus == Camera.locked)camera.unlock()
+                camera.searchAndLock()
+            }
+            onDoubleClicked: {
+                root.state = "Stopped"
+            }
+        }
+    }
+
+    MessageDialog {
+        id: messageDialog
+        title: "Scanning QrCode"
+        onAccepted: {
+            root.state = "Stopped"
+        }
+    }
+}

--- a/main.cpp
+++ b/main.cpp
@@ -39,6 +39,7 @@
 #include "WalletManager.h"
 #include "Wallet.h"
 #include "QRCodeImageProvider.h"
+#include "QrCodeScanner.h"
 #include "PendingTransaction.h"
 #include "TranslationManager.h"
 #include "TransactionInfo.h"
@@ -105,6 +106,8 @@ int main(int argc, char *argv[])
     qRegisterMetaType<TransactionInfo::Direction>();
     qRegisterMetaType<TransactionHistoryModel::TransactionInfoRole>();
 
+    qmlRegisterType<QrCodeScanner>("moneroComponents.QRCodeScanner", 1, 0, "QRCodeScanner");
+
     QQmlApplicationEngine engine;
 
     OSCursor cursor;
@@ -162,6 +165,12 @@ int main(int argc, char *argv[])
     QObject::connect(eventFilter, SIGNAL(mouseReleased(QVariant,QVariant,QVariant)), rootObject, SLOT(mouseReleased(QVariant,QVariant,QVariant)));
 
     //WalletManager::instance()->setLogLevel(WalletManager::LogLevel_Max);
+
+    QObject *qmlCamera = rootObject->findChild<QObject*>("qrCameraQML");
+    QCamera *camera_ = qvariant_cast<QCamera*>(qmlCamera->property("mediaObject"));
+    QObject *qmlFinder = rootObject->findChild<QObject*>("QrFinder");
+    QrCodeScanner *finder =  qobject_cast<QrCodeScanner*>(qmlFinder);
+    finder->setSource(camera_);
 
     return app.exec();
 }

--- a/main.qml
+++ b/main.qml
@@ -795,7 +795,10 @@ ApplicationWindow {
         messageText: qsTr("Please wait...")
     }
 
-
+    QRCodeScanner {
+        id: cameraUi
+        visible : false
+    }
 
     Item {
         id: rootItem

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick widgets
+QT += qml quick widgets multimedia
 
 WALLET_ROOT=$$PWD/monero
 
@@ -12,6 +12,7 @@ QMAKE_DISTCLEAN += -r $$WALLET_ROOT
 INCLUDEPATH += $$WALLET_ROOT/include \
                 $$PWD/src/libwalletqt \
                 $$PWD/src/QR-Code-generator \
+                $$PWD/src/QR-Code-scanner \
                 $$PWD/src \
                 $$WALLET_ROOT/src
 
@@ -36,8 +37,9 @@ HEADERS += \
     src/daemon/DaemonManager.h \
     src/model/AddressBookModel.h \
     src/libwalletqt/AddressBook.h \
-    src/zxcvbn-c/zxcvbn.h
-
+    src/zxcvbn-c/zxcvbn.h \
+    src/QR-Code-scanner/QZBarThread.h \
+    src/QR-Code-scanner/QrCodeScanner.h 
 
 SOURCES += main.cpp \
     filter.cpp \
@@ -59,7 +61,9 @@ SOURCES += main.cpp \
     src/daemon/DaemonManager.cpp \
     src/model/AddressBookModel.cpp \
     src/libwalletqt/AddressBook.cpp \
-    src/zxcvbn-c/zxcvbn.c
+    src/zxcvbn-c/zxcvbn.c \
+    src/QR-Code-scanner/QZBarThread.cpp \
+    src/QR-Code-scanner/QrCodeScanner.cpp 
 
 lupdate_only {
 SOURCES = *.qml \
@@ -111,6 +115,7 @@ win32 {
         -lboost_program_options-mt-s \
         -lssl \
         -lcrypto \
+        -lzbar \
         -Wl,-Bdynamic \
         -lws2_32 \
         -lwsock32 \
@@ -162,6 +167,14 @@ linux {
     
 }
 
+linux:!android {
+    LIBS += -lzbar
+}
+android {
+    INCLUDEPATH += $$PWD/../ZBar/include
+    LIBS += -lzbarjni -liconv
+}
+
 macx {
     # mixing static and shared libs are not supported on mac
     # CONFIG(static) {
@@ -182,6 +195,7 @@ macx {
         -lboost_program_options \
         -lssl \
         -lcrypto \
+        -lzbar \
         -ldl
 
 }

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import QtQuick 2.0
+import QtMultimedia 5.4
 import "../components"
 import moneroComponents.AddressBook 1.0
 import moneroComponents.AddressBookModel 1.0
@@ -62,12 +63,31 @@ Rectangle {
         tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
+    StandardButton {
+        id: qrfinderButton
+        anchors.left: parent.left
+        anchors.leftMargin: 17
+        anchors.topMargin: 5
+        anchors.top: addressLabel.bottom
+        text: qsTr("QRCODE") + translationManager.emptyString
+        shadowReleasedColor: "#FF4304"
+        shadowPressedColor: "#B32D00"
+        releasedColor: "#FF6C3C"
+        pressedColor: "#FF4304"
+        visible : QtMultimedia.availableCameras.length > 0
+        enabled : visible
+        width: visible ? 60 : 0
+        onClicked: {
+            cameraUi.state = "PhotoCapture"
+            cameraUi.qrcode_decoded.connect(updateFromQrCode)
+        }
+    }
+
     LineEdit {
         id: addressLine
-        anchors.left: parent.left
+        anchors.left: qrfinderButton.right
         anchors.right: parent.right
         anchors.top: addressLabel.bottom
-        anchors.leftMargin: 17
         anchors.rightMargin: 17
         anchors.topMargin: 5
         error: true;
@@ -275,5 +295,13 @@ Rectangle {
         root.model = currentWallet.addressBookModel;
     }
 
+    function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name) {
+        console.log("updateFromQrCode")
+        addressLine.text = address
+        paymentIdLine.text = payment_id
+        //amountLine.text = amount
+        descriptionLine.text = recipient_name + " " + tx_description
+        cameraUi.qrcode_decoded.disconnect(updateFromQrCode)
+    }
 
 }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -29,6 +29,7 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2
+import QtMultimedia 5.4
 import moneroComponents.PendingTransaction 1.0
 import "../components"
 import moneroComponents.Wallet 1.0
@@ -75,6 +76,15 @@ Rectangle {
         print ("PrivacyLevel changed:"  + fillLevel)
         print ("mixin count: "  + mixin)
         privacyLabel.text = qsTr("Privacy level (mixin %1)").arg(mixin) + translationManager.emptyString
+    }
+
+    function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name) {
+        console.log("updateFromQrCode")
+        addressLine.text = address
+        paymentIdLine.text = payment_id
+        amountLine.text = amount
+        descriptionLine.text = recipient_name + " " + tx_description
+        cameraUi.qrcode_decoded.disconnect(updateFromQrCode)
     }
 
     // Information dialog
@@ -246,11 +256,29 @@ Rectangle {
         anchors.right: parent.right
         anchors.top: addressLabel.bottom
 
+        StandardButton {
+            id: qrfinderButton
+            anchors.left: parent.left
+            anchors.leftMargin: 17
+            anchors.topMargin: 5
+            text: qsTr("QRCODE") + translationManager.emptyString
+            shadowReleasedColor: "#FF4304"
+            shadowPressedColor: "#B32D00"
+            releasedColor: "#FF6C3C"
+            pressedColor: "#FF4304"
+            visible : QtMultimedia.availableCameras.length > 0
+            enabled : visible
+            width: visible ? 60 : 0
+            onClicked: {
+                cameraUi.state = "PhotoCapture"
+                cameraUi.qrcode_decoded.connect(updateFromQrCode)
+            }
+        }
         LineEdit {
             id: addressLine
-            anchors.left: parent.left
+            anchors.left: qrfinderButton.right
             anchors.right: resolveButton.left
-            anchors.leftMargin: 17
+            //anchors.leftMargin: 17
             anchors.topMargin: 5
             placeholderText: "4..."
             // validator: RegExpValidator { regExp: /[0-9A-Fa-f]{95}/g }

--- a/qml.qrc
+++ b/qml.qrc
@@ -122,5 +122,6 @@
         <file>pages/Sign.qml</file>
         <file>components/DaemonManagerDialog.qml</file>
         <file>version.js</file>
+        <file>components/QRCodeScanner.qml</file>
     </qresource>
 </RCC>

--- a/src/QR-Code-scanner/QZBarThread.cpp
+++ b/src/QR-Code-scanner/QZBarThread.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2014-2016, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally Copyright 2008-2009 (c) Jeff Brown <spadix@users.sourceforge.net> (ZBar)
+
+#include "QZBarThread.h"
+#include <QDebug>
+
+//Function that was in qandroidmultimediautils.cpp, removed in qt 5.3
+void qt_convert_NV21_to_ARGB32(const uchar *yuv, quint32 *rgb, int width, int height)
+{
+    const int frameSize = width * height;
+
+    int a = 0;
+    for (int i = 0, ci = 0; i < height; ++i, ci += 1) {
+        for (int j = 0, cj = 0; j < width; ++j, cj += 1) {
+            int y = (0xff & ((int) yuv[ci * width + cj]));
+            int v = (0xff & ((int) yuv[frameSize + (ci >> 1) * width + (cj & ~1) + 0]));
+            int u = (0xff & ((int) yuv[frameSize + (ci >> 1) * width + (cj & ~1) + 1]));
+            y = y < 16 ? 16 : y;
+
+            int r = (int) (1.164f * (y - 16) + 1.596f * (v - 128));
+            int g = (int) (1.164f * (y - 16) - 0.813f * (v - 128) - 0.391f * (u - 128));
+            int b = (int) (1.164f * (y - 16) + 2.018f * (u - 128));
+
+            r = qBound(0, r, 255);
+            g = qBound(0, g, 255);
+            b = qBound(0, b, 255);
+
+            rgb[a++] = 0xff000000 | (r << 16) | (g << 8) | b;
+        }
+    }
+}
+
+QZBarThread::QZBarThread (QObject *parent)
+      : QThread(parent)
+       ,running(true)
+{
+    scanner.set_handler(*this);
+}
+
+void QZBarThread::image_callback(zbar::Image &image)
+{
+    qDebug() << "image_callback :  Found Code ! " ;
+    for(zbar::Image::SymbolIterator sym = image.symbol_begin();
+        sym != image.symbol_end();
+        ++sym)
+        if(!sym->get_count()) {
+            QString data = QString::fromStdString(sym->get_data());
+            emit decoded(sym->get_type(), data);
+        }
+}
+
+void QZBarThread::processImage(zbar::Image &image)
+{
+    scanner.recycle_image(image);
+    zbar::Image tmp = image.convert(*(long*)"Y800");
+    scanner.scan(tmp);
+    image.set_symbols(tmp.get_symbols());
+}
+void QZBarThread::scanImageEvent(ScanImageEvent *e)
+{
+    try {
+        image = QSharedPointer<QZBarImage>(new QZBarImage(e->image));
+        processImage(*image);
+    }
+    catch(std::exception &e) {
+        qDebug() << "ERROR: " << e.what();
+        emit notifyError(e.what());
+    }
+}
+void QZBarThread::scanVideoEvent(ScanVideoEvent *e)
+{
+    QVideoFrame frame = e->frame;
+    frame.map(QAbstractVideoBuffer::ReadOnly);
+
+    QImage img;
+    if(frame.pixelFormat() == QVideoFrame::Format_NV21) {
+        img = QImage(frame.size(), QImage::Format_ARGB32);
+        qt_convert_NV21_to_ARGB32(frame.bits(), (quint32 *)img.bits(), frame.width(), frame.height() ) ;
+    } else {
+        QImage::Format imageFormat = QVideoFrame::imageFormatFromPixelFormat(frame.pixelFormat());
+        if( imageFormat == QImage::Format_Invalid){
+            QString serror = QString("Failed to convert pixel format \"%1\" to \"%2\" ! ").arg(frame.pixelFormat()).arg(imageFormat);
+            emit notifyError(serror);
+            return;
+        }
+        img = QImage(frame.bits(), frame.width(), frame.height(), frame.bytesPerLine(), imageFormat);
+        if(img.isNull()){
+             QString serror = QString("Failed to convert pixel format \"%1\" to \"%2\" ! ").arg(frame.pixelFormat()).arg(imageFormat);
+             emit notifyError(serror);
+             return;
+        }
+    }
+    try{
+        image = QSharedPointer<QZBarImage>(new QZBarImage(img));
+        processImage(*image);
+    }
+    catch(std::exception &e) {
+        qDebug() << "ERROR: " << e.what();
+        emit notifyError(e.what());
+    }
+}
+bool QZBarThread::event(QEvent *e)
+{
+    switch((EventType)e->type()) {
+    case ScanImage:
+        scanImageEvent((ScanImageEvent*)e);
+        break;
+    case ScanVideo:
+        scanVideoEvent((ScanVideoEvent*)e);
+        break;
+    case Exit:
+        running = false;
+        break;
+    default:
+        return(false);
+    }
+    return(true);
+}
+
+void QZBarThread::run()
+{
+    QEvent *e = NULL;
+    while(running) {
+        QMutexLocker locker(&mutex);
+        while(queue.isEmpty())
+            newEvent.wait(&mutex);
+        e = queue.takeFirst();
+
+        if(e) {
+            event(e);
+            delete e;
+            e = NULL;
+        }
+    }
+}
+

--- a/src/QR-Code-scanner/QZBarThread.h
+++ b/src/QR-Code-scanner/QZBarThread.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2014-2016, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally Copyright 2008-2009 (c) Jeff Brown <spadix@users.sourceforge.net> (ZBar)
+
+#ifndef _QZBARTHREAD_H_
+#define _QZBARTHREAD_H_
+
+#include <QThread>
+#include <QMutex>
+#include <QWaitCondition>
+#include <QEvent>
+#include <QVideoFrame>
+#include <zbar.h>
+#include <QCamera>
+#include <QCameraImageCapture>
+#include <QMediaRecorder>
+#include <QAbstractVideoSurface>
+
+#ifndef zbar_fourcc
+#define zbar_fourcc(a, b, c, d)                 \
+        ((unsigned long)(a) |                   \
+         ((unsigned long)(b) << 8) |            \
+         ((unsigned long)(c) << 16) |           \
+         ((unsigned long)(d) << 24))
+#endif
+
+
+class QZBarImage : public zbar::Image
+{
+public:
+
+    /// construct a zbar library image based on an existing QImage.
+    QZBarImage (const QImage &qimg) : qimg(qimg)
+    {
+        QImage::Format fmt = qimg.format();
+        if(fmt != QImage::Format_RGB32 &&
+           fmt != QImage::Format_ARGB32 &&
+           fmt != QImage::Format_ARGB32_Premultiplied)
+            throw zbar::FormatError();
+
+        unsigned bpl = qimg.bytesPerLine();
+        unsigned width = bpl / 4;
+        unsigned height = qimg.height();
+        set_size(width, height);
+        set_format(zbar_fourcc('B','G','R','4'));
+        unsigned long datalen = qimg.byteCount();
+        set_data(qimg.bits(), datalen);
+
+        if((width * 4 != bpl) || (width * height * 4 > datalen))
+            throw zbar::FormatError();
+    }
+
+private:
+    QImage qimg;
+};
+
+class QZBarThread : public QThread, public zbar::Image::Handler
+{
+    Q_OBJECT
+
+public:
+    enum EventType {
+        ScanImage = QEvent::User,
+        ScanVideo,
+        Exit = QEvent::MaxUser
+    };
+
+    class ScanImageEvent : public QEvent {
+    public:
+        ScanImageEvent (const QImage &image)
+            : QEvent((QEvent::Type)ScanImage),
+              image(image)
+        { }
+        const QImage image;
+    };
+
+    class ScanVideoEvent : public QEvent {
+    public:
+        ScanVideoEvent (const QVideoFrame &frame)
+            : QEvent((QEvent::Type)ScanVideo),
+              frame(frame)
+        { }
+        const QVideoFrame frame;
+    };
+
+    QMutex mutex;
+    QWaitCondition newEvent;
+    QList<QEvent*> queue;
+
+    QZBarThread(QObject *parent = Q_NULLPTR);
+
+    void pushEvent (QEvent *e)
+    {
+        QMutexLocker locker(&mutex);
+        queue.append(e);
+        newEvent.wakeOne();
+    }
+
+Q_SIGNALS:
+    void decoded(int type, const QString &data);
+    void notifyError(const QString &error, bool warning = false);
+
+protected:
+    virtual void run();
+
+    virtual void image_callback(zbar::Image &image);
+    void processImage(zbar::Image &image);
+
+    virtual bool event(QEvent *e);
+    virtual void scanImageEvent(ScanImageEvent *event);
+    virtual void scanVideoEvent(ScanVideoEvent *event);
+
+private:
+    zbar::ImageScanner scanner;
+    QSharedPointer<QZBarImage> image;
+    bool running;
+};
+
+#endif

--- a/src/QR-Code-scanner/QrCodeScanner.cpp
+++ b/src/QR-Code-scanner/QrCodeScanner.cpp
@@ -1,0 +1,81 @@
+#include "QrCodeScanner.h"
+#include <WalletManager.h>
+#include <QVideoProbe>
+
+QrCodeScanner::QrCodeScanner(QObject *parent) 
+    : QObject(parent), 
+      _processTimerId(-1),
+      _processInterval(750), 
+      _enabled(true), 
+      _readerThread( new QZBarThread(this) ),
+      _probe( new QVideoProbe(this) )
+{ 
+    _readerThread->start(); 
+ 
+    QObject::connect(_readerThread, SIGNAL(decodedText(QString)), this, SIGNAL(decode(QString))); 
+    QObject::connect(_readerThread, SIGNAL(decoded(int,QString)), this, SLOT(processCode(int,QString))); 
+    QObject::connect(_readerThread, SIGNAL(notifyError(const QString &, bool)), this, SIGNAL(notifyError(const QString &, bool)));
+
+    connect(_probe, SIGNAL(videoFrameProbed(QVideoFrame)), this, SLOT(processFrame(QVideoFrame)));
+} 
+void QrCodeScanner::setSource(QCamera *camera)
+{
+    _probe->setSource(camera);
+}
+void QrCodeScanner::processCode(int type, const QString &data)
+{
+    if (_enabled) {
+        qDebug() << "decoded - type: " << type << " data: " << data;
+        QString address, payment_id, tx_description, recipient_name, error;
+        QVector<QString> unknown_parameters;
+        uint64_t amount(0); 
+        if( ! WalletManager::instance()->parse_uri(data, address, payment_id, amount, tx_description, recipient_name, unknown_parameters, error) )
+        {
+            qDebug() << "Failed to parse_uri : " << error;
+            emit notifyError(error);
+            return;
+        }
+        if(unknown_parameters.size() > 0)
+        {
+            qDebug() << "unknown parameters " << unknown_parameters;
+            emit notifyError(error, true);
+        }
+        qDebug() << "Parsed URI : " << address << " " << payment_id << " " << amount << " " << tx_description << " " << recipient_name << " " << error;
+        QString s_amount = WalletManager::instance()->displayAmount(amount);
+        qDebug() << "Amount passed " << s_amount ;
+        emit decoded(address, payment_id, s_amount, tx_description, recipient_name);
+    }
+}
+void QrCodeScanner::processFrame(QVideoFrame frame)
+{
+    if(frame.isValid()){
+        _curFrame = frame;
+    }
+}
+bool QrCodeScanner::enabled() const
+{
+    return _enabled;
+}
+void QrCodeScanner::setEnabled(bool enabled)
+{
+    _enabled = enabled;
+    if(!enabled && (_processTimerId != -1) )
+    {
+        this->killTimer(_processTimerId);
+        _processTimerId = -1;
+    }
+    else if (enabled && (_processTimerId == -1) )
+    {
+        _processTimerId = this->startTimer(_processInterval);
+    }
+    emit enabledChanged();
+}
+void QrCodeScanner::timerEvent(QTimerEvent *event)
+{
+    if (!_enabled)
+        return;
+    if(event->timerId() == _processTimerId && _curFrame.isValid()){
+        _readerThread->pushEvent(new QZBarThread::ScanVideoEvent(_curFrame));
+    }
+}
+

--- a/src/QR-Code-scanner/QrCodeScanner.h
+++ b/src/QR-Code-scanner/QrCodeScanner.h
@@ -1,0 +1,46 @@
+#ifndef QRCODESCANNER_H_
+#define QRCODESCANNER_H_
+
+#include "QZBarThread.h"
+
+class QVideoProbe;
+
+class QrCodeScanner : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+
+public:
+    QrCodeScanner(QObject *parent = Q_NULLPTR);
+
+    void setSource(QCamera*);
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+public Q_SLOTS:
+    void processCode(int type, const QString &data);
+    void processFrame(QVideoFrame);
+
+Q_SIGNALS:
+    void enabledChanged();
+
+    void decoded(const QString &address, const QString &payment_id, const QString &amount, const QString &tx_description, const QString &recipient_name);
+    void decode(int type, const QString &data);
+    void notifyError(const QString &error, bool warning = false);
+
+protected:
+    void timerEvent(QTimerEvent *);
+
+    int _processTimerId;
+    int _processInterval;
+    int _enabled;
+    QImage _currentFrame;
+    QVideoFrame _curFrame;
+    QZBarThread *_readerThread;
+    QVideoProbe *_probe;
+};
+
+#endif
+


### PR DESCRIPTION
Adds a new dependency : libzbar !

How it works:
-- Button visible if camera available
-- onClick : Camera -> QVideoProbe -> store last QVideoFrame
-- Timer 750ms : copy last frame to proccessing thread -> conversion videoframe -> scan with zbar -> emit signals

Comments:
-- Needs  #396 
-- Not tested on windows and mac
-- QZBarThread .h/.cpp : impossible to use the original because it is for Qt4 and has x11 dependencies.
-- I not only dit not write "qt_convert_NV21_to_ARGB32" but i don't understand it (but it works perfectly :) )
-- Needs better UX (anyone interested ?)
-- QrCodes on Poloniex are not compliant with spec !
-- On android, Zbarjni dynamic lib (downloaded or built) + unwind = kaboom. Static build OK
-- Should help close #5

Bugs :
-- QmlCamera may fails to detect camera (Qt demo example "declarative-camera" doesn't work on my laptop).
-- libzbar needs 32 bits image format and the default conversion algorithm may not work.

Should not be merged currently :
I'm only pushing this to ask for the pixel format used by the main platforms to add specific conversion algo if needed. So please, if you see "Failed to convert pixel format ", report the numbers printed.