### PR TITLE
monero submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "monero"]
+	path = monero
+	url = https://github.com/monero-project/monero
+    ignore = dirty

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ MONERO_DIR=monero
 MONEROD_EXEC=monerod
 
 # Build libwallet if monero folder doesnt exist
-if [ ! -d $MONERO_DIR ]; then 
+if [ ! -d $MONERO_DIR/src ]; then 
     $SHELL get_libwallet_api.sh $BUILD_TYPE
 fi
  

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -54,14 +54,11 @@ source $ROOT_DIR/utils.sh
 INSTALL_DIR=$ROOT_DIR/wallet
 MONERO_DIR=$ROOT_DIR/monero
 
-
-if [ ! -d $MONERO_DIR ]; then
-    git clone --depth=1 $MONERO_URL $MONERO_DIR --branch $MONERO_BRANCH --single-branch
-else
-    cd $MONERO_DIR;
-    git checkout $MONERO_BRANCH
-    git pull;
+# init and update monero submodule
+if [ ! -d $MONERO_DIR/src ]; then
+    git submodule init monero
 fi
+git submodule update
 
 echo "cleaning up existing monero build dir, libs and includes"
 rm -fr $MONERO_DIR/build


### PR DESCRIPTION
This PR adds monero as a submodule. The submodule is linked to a specific commit and won't pull latest HEAD automatically. This will hopefully make testning easier when PR's are merged into monero that doesn't build on all platforms.

Fixes point 3 of https://github.com/monero-project/monero-core/issues/62