### PR TITLE
Change slider mixin=4 term from "low" to "normal"

### DIFF
--- a/components/TickDelegate.qml
+++ b/components/TickDelegate.qml
@@ -52,7 +52,7 @@ Item {
             font.pixelSize: 12
             color: "#4A4949"
             text: {
-                if(currentIndex === 0) return qsTr("LOW") + translationManager.emptyString
+                if(currentIndex === 0) return qsTr("NORMAL") + translationManager.emptyString
                 if(currentIndex === 3) return qsTr("MEDIUM") + translationManager.emptyString
                 if(currentIndex === 13) return qsTr("HIGH") + translationManager.emptyString
                 return ""


### PR DESCRIPTION
A mixin of 4 isn't really "low" privacy. If people want a higher mixin, that's great, and the HIGH term does convey that a mixin of 25 is higher privacy than the default setting. But the default setting should not convey that privacy is LOW. In fact, the default mixin is among the most private tx a person can send in all of cryptoland. A better term for default XMR privacy (mixin=4) is something like "normal" / "standard" / "typical" / "average" / "default". Of these "normal" seems the best for the newbie Monero user.