### PR TITLE
Better medium mixin color

### DIFF
--- a/components/PrivacyLevel.qml
+++ b/components/PrivacyLevel.qml
@@ -64,7 +64,7 @@ Item {
 
             color: {
                 if(item.fillLevel < 3) return "#FF6C3C"
-                if(item.fillLevel < 13) return "#FFE00A"
+                if(item.fillLevel < 13) return "#AAFFBB"
                 return "#36B25C"
             }
 

--- a/components/PrivacyLevelSmall.qml
+++ b/components/PrivacyLevelSmall.qml
@@ -73,7 +73,7 @@ Item {
 
             color: {
                 if(item.fillLevel < 5) return "#FF6C3C"
-                if(item.fillLevel < 13) return "#FFE00A"
+                if(item.fillLevel < 13) return "#AAFFBB"
                 return "#36B25C"
             }
 


### PR DESCRIPTION
Currently the colors are Low/orange, Medium/yellow, and High/green. I understand orange being low, since it's the default color of Monero. High/dark-green makes sense since green has a feeling of "go", or of safety, good for a high privacy setting. But medium being yellow is awkward, since it looks like an alarming/warning color.

A better color for Medium would be the light green seen in the Receive bullet point (#AAFFBB) vs. the dark green/High color in the Settings bullet point. That way the mixin slider changes from orange to light green ("go/safe") to dark green (very "go/safe"), and the deeper the green the higher the conveyed sense of privacy.