### PR TITLE
Clearer results for Verify Payment tool

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -622,7 +622,7 @@ ApplicationWindow {
                 else {
                     var dCurrentBlock = currentWallet.daemonBlockChainHeight();
                     var confirmations = dCurrentBlock - height
-                    informationPopup.text = qsTr("This address received %1 monero, with %2 confirmations").arg(received).arg(confirmations);
+                    informationPopup.text = qsTr("This address received %1 monero, with %2 confirmation(s).").arg(received).arg(confirmations);
                 }
             }
             else {


### PR DESCRIPTION
Changed confirmations to confirmation(s) so the tool doesn't say "with 1 confirmations". Also added a period to the end of the sentence.