### PR TITLE
Allow some QT lib paths to be set in environment variables

### DIFF
--- a/linuxdeploy_helper.sh
+++ b/linuxdeploy_helper.sh
@@ -11,12 +11,12 @@ platform=$(get_platform)
 
 # Copy dependencies
 EXCLUDE='libstdc++|libgcc_s.so|libc.so|libpthread'
-cp -rv /usr/lib/x86_64-linux-gnu/qt5/qml $TARGET
-cp -rv /usr/lib/x86_64-linux-gnu/qt5/plugins $TARGET
-mkdir -p $TARGET/libs
-ldd $TARGET/$GUI_EXEC | grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs
-ldd $TARGET/plugins/platforms/libqxcb.so| grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs
-cp -v /usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5 $TARGET/libs
+cp -rv /usr/lib/x86_64-linux-gnu/qt5/qml $TARGET || exit
+cp -rv /usr/lib/x86_64-linux-gnu/qt5/plugins $TARGET || exit
+mkdir -p $TARGET/libs || exit
+ldd $TARGET/$GUI_EXEC | grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs || exit
+ldd $TARGET/plugins/platforms/libqxcb.so| grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs || exit
+cp -v /usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5 $TARGET/libs || exit
 
 # Create start script
 cat > $TARGET/start-gui.sh <<EOL

--- a/linuxdeploy_helper.sh
+++ b/linuxdeploy_helper.sh
@@ -9,14 +9,34 @@ GUI_EXEC=$2
 
 platform=$(get_platform)
 
+if [[ "$platform" == "linux64" ]]; then
+    PLAT_DIR="/usr/lib/x86_64-linux-gnu"
+elif [[ "$platform" == "linux32" ]]; then
+    PLAT_DIR="/usr/lib/i386-linux-gnu"
+elif [[ "$platform" == "linuxarmv7" ]]; then
+    PLAT_DIR="/usr/lib/arm-linux-gnueabihf"
+elif [[ "$platform" == "linuxarmv8" ]]; then
+    PLAT_DIR="/usr/lib/aarch64-linux-gnu"
+else
+    PLAT_DIR="/usr/lib"
+fi
+
+if [ -z "$QT_DIR" ]; then
+    QT_DIR=$PLAT_DIR/qt5
+fi
+
+if [ -z "$QTXML_DIR" ]; then
+    QTXML_DIR=$PLAT_DIR
+fi
+
 # Copy dependencies
 EXCLUDE='libstdc++|libgcc_s.so|libc.so|libpthread'
-cp -rv /usr/lib/x86_64-linux-gnu/qt5/qml $TARGET || exit
-cp -rv /usr/lib/x86_64-linux-gnu/qt5/plugins $TARGET || exit
+cp -rv $QT_DIR/qml $TARGET || exit
+cp -rv $QT_DIR/plugins $TARGET || exit
 mkdir -p $TARGET/libs || exit
 ldd $TARGET/$GUI_EXEC | grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs || exit
 ldd $TARGET/plugins/platforms/libqxcb.so| grep "=> /" | awk '{print $3}' | grep -Ev $EXCLUDE | xargs -I '{}' cp -v '{}' $TARGET/libs || exit
-cp -v /usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5 $TARGET/libs || exit
+cp -v $QTXML_DIR/libQt5XmlPatterns.so.5 $TARGET/libs || exit
 
 # Create start script
 cat > $TARGET/start-gui.sh <<EOL

--- a/utils.sh
+++ b/utils.sh
@@ -10,7 +10,11 @@ function get_platform {
             platform="linux64"
         elif [ "$(expr substr $(uname -m) 1 4)" == "i686" ]; then
             platform="linux32"
-        else
+        elif [ "$(expr substr $(uname -m) 1 6)" == "armv7l" ]; then
+            platform="linuxarmv7"
+	elif [ "$(expr substr $(uname -m) 1 7)" == "aarch64" ]; then
+            platform="linuxarmv8"
+	else
             platform="linux"
         fi
     elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then


### PR DESCRIPTION
Depending on the architecture, distribution, and where I installed QT from, these paths are different. Unless someone has a better idea, if we just allow them to be set like this I can make adjustments locally.