### PR TITLE
Terminology change: switch "mixin" with "ring size"

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -464,7 +464,7 @@ ApplicationWindow {
                         + (paymentId === "" ? "" : (qsTr("\nPayment ID: ") + paymentId))
                         + qsTr("\n\nAmount: ") + walletManager.displayAmount(transaction.amount)
                         + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee)
-                        + qsTr("\n\nMixin: ") + mixinCount
+                        + qsTr("\n\nRing size: ") + mixinCount
                         + qsTr("\n\Number of transactions: ") + transaction.txCount
                         + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))
                         + translationManager.emptyString

--- a/main.qml
+++ b/main.qml
@@ -464,7 +464,7 @@ ApplicationWindow {
                         + (paymentId === "" ? "" : (qsTr("\nPayment ID: ") + paymentId))
                         + qsTr("\n\nAmount: ") + walletManager.displayAmount(transaction.amount)
                         + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee)
-                        + qsTr("\n\nRing size: ") + mixinCount
+                        + qsTr("\n\nRing size: ") + mixinCount + 1
                         + qsTr("\n\Number of transactions: ") + transaction.txCount
                         + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))
                         + translationManager.emptyString

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -74,7 +74,7 @@ Rectangle {
         var mixin = scaleValueToMixinCount(fillLevel)
         print ("PrivacyLevel changed:"  + fillLevel)
         print ("mixin count: "  + mixin)
-        privacyLabel.text = qsTr("Privacy level (ring size %1)").arg(mixin) + translationManager.emptyString
+        privacyLabel.text = qsTr("Privacy level (ring size %1)").arg(mixin+1) + translationManager.emptyString
     }
 
     // Information dialog
@@ -560,7 +560,7 @@ Rectangle {
                     + (transaction.paymentId[i] == "" ? "" : qsTr("\n\payment ID: ") + transaction.paymentId[i])
                     + qsTr("\nAmount: ") + walletManager.displayAmount(transaction.amount(i))
                     + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee(i))
-                    + qsTr("\nRing size: ") + transaction.mixin(i)
+                    + qsTr("\nRing size: ") + transaction.mixin(i+1)
 
                     // TODO: add descriptions to unsigned_tx_set?
     //              + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -74,7 +74,7 @@ Rectangle {
         var mixin = scaleValueToMixinCount(fillLevel)
         print ("PrivacyLevel changed:"  + fillLevel)
         print ("mixin count: "  + mixin)
-        privacyLabel.text = qsTr("Privacy level (mixin %1)").arg(mixin) + translationManager.emptyString
+        privacyLabel.text = qsTr("Privacy level (ring size %1)").arg(mixin) + translationManager.emptyString
     }
 
     // Information dialog
@@ -560,7 +560,7 @@ Rectangle {
                     + (transaction.paymentId[i] == "" ? "" : qsTr("\n\payment ID: ") + transaction.paymentId[i])
                     + qsTr("\nAmount: ") + walletManager.displayAmount(transaction.amount(i))
                     + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee(i))
-                    + qsTr("\nMixin: ") + transaction.mixin(i)
+                    + qsTr("\nRing size: ") + transaction.mixin(i)
 
                     // TODO: add descriptions to unsigned_tx_set?
     //              + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))


### PR DESCRIPTION
As per the discussion here:

https://www.reddit.com/r/Monero/comments/5pmz3f/maybe_a_good_idea_to_rename_mixin_in_the_code_to/

Good point by u/knaccc: "For mass adoption, people should not need to understand what a ring signature is, and then understand the mathematics of using different mixin levels, in order to feel comfortable sending a payment."

This change fits this desire well. The privacy slider is still titled "Privacy level", which even newbies can understand has something to do with increasing the privacy of the tx. But in parentheses the term will say "ring size", which is a more accurate term than the current term "mixin". Best of both worlds.