### PR TITLE
Simplified "OR ALL" button to "ALL"

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -152,7 +152,7 @@ Rectangle {
             //anchors.top: amountLine.top
             //anchors.bottom: amountLine.bottom
             width: 60
-            text: qsTr("or ALL") + translationManager.emptyString
+            text: qsTr("ALL") + translationManager.emptyString
             shadowReleasedColor: "#FF4304"
             shadowPressedColor: "#B32D00"
             releasedColor: "#FF6C3C"


### PR DESCRIPTION
The purpose of keeping "OR" in the button was to avoid people accidentally sending their entire account balance, ie. keeping "OR" helps the user realize the button is completely optional and not required for an XMR transaction.

However, "OR ALL" looks awkward as is, and the functionality is still intuitive if simplified to "ALL", so that is the purpose of this PR.