### PR TITLE
Payment Description into placeholder

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -340,7 +340,7 @@ Rectangle {
         anchors.rightMargin: 17
         anchors.topMargin: 17
         fontSize: 14
-        text: qsTr("Description <font size='2'>( Optional - saved to local wallet history )</font>")
+        text: qsTr("Description <font size='2'>( Optional )</font>")
               + translationManager.emptyString
     }
 
@@ -352,6 +352,7 @@ Rectangle {
         anchors.leftMargin: 17
         anchors.rightMargin: 17
         anchors.topMargin: 5
+        placeholderText: qsTr("Saved to local wallet history") + translationManager.emptyString
     }
 
     function checkInformation(amount, address, payment_id, testnet) {


### PR DESCRIPTION
Mimics the same design as Payment ID. Keep description of field in placeholder rather than above the field as how Description originally was.