### PR TITLE
potential fix Parse error monero-core_de.ts:500:59:

### DIFF
--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -497,7 +497,7 @@
     <message>
         <location filename="../pages/Receive.qml" line="129"/>
         <source>%2 confirmations: %3 (%1)</source>
-        <translation type="unfinished">%2 Bestätigungen: &%3 (%1)</translation>
+        <translation type="unfinished">%2 Bestätigungen: %3 (%1)</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="131"/>


### PR DESCRIPTION
Error during build:

/usr/bin/lrelease -compress -nounfinished -removeidentical ../translations/monero-core_de.ts -qm /x/monero-core/build/release/bin/translations/monero-core_de.qm
lrelease error: Parse error at ../translations/monero-core_de.ts:500:59: Expected '#' or '[a-zA-Z]', but got '%'.

Appears to be a typo in german translation file. Removing character builds this stage OK