### PR TITLE
Potential fix for undefined reference 'dlsym' linux

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -201,6 +201,9 @@ linux {
         contains(QT_ARCH, x86_64) {
             LIBS+= -lunbound
         }
+    } else {
+      # On some distro's we need to all dynload
+      LIBS+= -ldl
     }
 
     LIBS+= \
@@ -214,7 +217,6 @@ linux {
         -lboost_program_options \
         -lssl \
         -lcrypto \
-        -ldl \
         -Wl,-Bdynamic \
         -lGL
     # currently monero has an issue with "static" build and linunwind-dev,

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -202,7 +202,7 @@ linux {
             LIBS+= -lunbound
         }
     } else {
-      # On some distro's we need to all dynload
+      # On some distro's we need to add dynload
       LIBS+= -ldl
     }
 

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -214,6 +214,7 @@ linux {
         -lboost_program_options \
         -lssl \
         -lcrypto \
+        -ldl \
         -Wl,-Bdynamic \
         -lGL
     # currently monero has an issue with "static" build and linunwind-dev,


### PR DESCRIPTION
Fix for undefined reference including ldl. add -ldl to linux LIBS for Makefile.

/usr/bin/ld: /tmp/ccYIfntN.ltrans11.ltrans.o: undefined reference to symbol 'dlsym@@GLIBC_2.2.5'
/usr/lib/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:388: release/bin/monero-wallet-gui] Error 1