### PR TITLE
Make "ringsize" one word

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -468,7 +468,7 @@ ApplicationWindow {
                         + (paymentId === "" ? "" : (qsTr("\nPayment ID: ") + paymentId))
                         + qsTr("\n\nAmount: ") + walletManager.displayAmount(transaction.amount)
                         + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee)
-                        + qsTr("\n\nRing size: ") + (mixinCount + 1)
+                        + qsTr("\n\nRingsize: ") + (mixinCount + 1)
                         + qsTr("\n\Number of transactions: ") + transaction.txCount
                         + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))
                         + translationManager.emptyString

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -74,7 +74,7 @@ Rectangle {
         var mixin = scaleValueToMixinCount(fillLevel)
         print ("PrivacyLevel changed:"  + fillLevel)
         print ("mixin count: "  + mixin)
-        privacyLabel.text = qsTr("Privacy level (ring size %1)").arg(mixin+1) + translationManager.emptyString
+        privacyLabel.text = qsTr("Privacy level (ringsize %1)").arg(mixin+1) + translationManager.emptyString
     }
 
     function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name) {
@@ -595,7 +595,7 @@ Rectangle {
                     + (transaction.paymentId[i] == "" ? "" : qsTr("\n\payment ID: ") + transaction.paymentId[i])
                     + qsTr("\nAmount: ") + walletManager.displayAmount(transaction.amount(i))
                     + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee(i))
-                    + qsTr("\nRing size: ") + transaction.mixin(i+1)
+                    + qsTr("\nRingsize: ") + transaction.mixin(i+1)
 
                     // TODO: add descriptions to unsigned_tx_set?
     //              + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))


### PR DESCRIPTION
See this discussion: https://github.com/monero-project/monero/issues/1673

Ringsize is being used as a single compound word (instead of "ring size" - two words) which makes sense in the mixin vs. mix in sense of things.