### PR TITLE
Attempt to fix rare crash when switching wallets

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -182,15 +182,6 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("defaultAccountName", accountName);
     engine.rootContext()->setContextProperty("applicationDirectory", QApplication::applicationDirPath());
 
-    // Load main window (context properties needs to be defined obove this line)
-    engine.load(QUrl(QStringLiteral("qrc:///main.qml")));
-    QObject *rootObject = engine.rootObjects().first();
-
-    QObject::connect(eventFilter, SIGNAL(sequencePressed(QVariant,QVariant)), rootObject, SLOT(sequencePressed(QVariant,QVariant)));
-    QObject::connect(eventFilter, SIGNAL(sequenceReleased(QVariant,QVariant)), rootObject, SLOT(sequenceReleased(QVariant,QVariant)));
-    QObject::connect(eventFilter, SIGNAL(mousePressed(QVariant,QVariant,QVariant)), rootObject, SLOT(mousePressed(QVariant,QVariant,QVariant)));
-    QObject::connect(eventFilter, SIGNAL(mouseReleased(QVariant,QVariant,QVariant)), rootObject, SLOT(mouseReleased(QVariant,QVariant,QVariant)));
-
     bool builtWithScanner = false;
 #ifdef WITH_SCANNER
     builtWithScanner = true;
@@ -200,6 +191,15 @@ int main(int argc, char *argv[])
     qobject_cast<QrCodeScanner*>(qmlFinder)->setSource(camera_);
 #endif
     engine.rootContext()->setContextProperty("builtWithScanner", builtWithScanner);
+
+    // Load main window (context properties needs to be defined obove this line)
+    engine.load(QUrl(QStringLiteral("qrc:///main.qml")));
+    QObject *rootObject = engine.rootObjects().first();
+
+    QObject::connect(eventFilter, SIGNAL(sequencePressed(QVariant,QVariant)), rootObject, SLOT(sequencePressed(QVariant,QVariant)));
+    QObject::connect(eventFilter, SIGNAL(sequenceReleased(QVariant,QVariant)), rootObject, SLOT(sequenceReleased(QVariant,QVariant)));
+    QObject::connect(eventFilter, SIGNAL(mousePressed(QVariant,QVariant,QVariant)), rootObject, SLOT(mousePressed(QVariant,QVariant,QVariant)));
+    QObject::connect(eventFilter, SIGNAL(mouseReleased(QVariant,QVariant,QVariant)), rootObject, SLOT(mouseReleased(QVariant,QVariant,QVariant)));
 
     return app.exec();
 }

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -600,7 +600,9 @@ Wallet::~Wallet()
     qDebug("~Wallet: Closing wallet");
 
     delete m_history;
+    m_history = NULL;
     //Monero::WalletManagerFactory::getWalletManager()->closeWallet(m_walletImpl);
     delete m_walletImpl;
+    m_walletImpl = NULL;
     qDebug("m_walletImpl deleted");
 }


### PR DESCRIPTION
I've experienced crashes when switching wallets after syncing from scratch. Seems like the asynchronous close is calling the destructor twice on rare occasions. 

+ fixed the undefined builtwithscanner error. 