### PR TITLE
omit --detach flag on windows

### DIFF
--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -27,7 +27,12 @@ bool DaemonManager::start(const QString &flags, bool testnet)
 {
     // prepare command line arguments and pass to monerod
     QStringList arguments;
+
+    // Start daemon with --detach flag on non-windows platforms
+#ifndef Q_OS_WIN
     arguments << "--detach";
+#endif
+
     if(testnet)
         arguments << "--testnet";
 
@@ -44,7 +49,7 @@ bool DaemonManager::start(const QString &flags, bool testnet)
             arguments << str;
     }
 
-    arguments << "--updates" << "disabled";
+    arguments << "--check-updates" << "disabled";
 
     qDebug() << "starting monerod " + m_monerod;
     qDebug() << "With command line arguments " << arguments;


### PR DESCRIPTION
monerod fails to start with --detach flag on windows. 