### PR TITLE
Remove reference to Taiwan from the codebase, replace with 'Traditional'

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -275,7 +275,7 @@ TRANSLATIONS =  \ # English is default language, no explicit translation file
                 $$PWD/translations/monero-core_nl.ts \ # Dutch
                 $$PWD/translations/monero-core_pl.ts \ # Polish
                 $$PWD/translations/monero-core_ru.ts \ # Russian
-                $$PWD/translations/monero-core_zh.ts \ # Chinese (Taiwan)
+                $$PWD/translations/monero-core_zh.ts \ # Chinese (Traditional)
 
 CONFIG(release, debug|release) {
     DESTDIR = release/bin


### PR DESCRIPTION
May seem petty, but it's a real political sticking-point in China

We're using the same 'Chinese' (mainland) flag for both traditional and simplified writing systems, so once someone writes a simplified translation file, we need to rename the translation files appropriately, and list them in the menu in their native Chinese names.