### PR TITLE
Better (smaller) font size for password box

### DIFF
--- a/wizard/WizardPasswordInput.qml
+++ b/wizard/WizardPasswordInput.qml
@@ -43,7 +43,7 @@ FocusScope {
         horizontalAlignment: TextInput.AlignLeft
         verticalAlignment: TextInput.AlignVCenter
         font.family: "Arial"
-        font.pixelSize: 32
+        font.pixelSize: 26
         echoMode: TextInput.Password
         style: TextFieldStyle {
             renderType: Text.NativeRendering


### PR DESCRIPTION
32px was way too big, looked awkward. 26px is much better, and matches the heading at the top of the page.
![screen shot 2017-02-27 at 8 23 10 pm](https://cloud.githubusercontent.com/assets/21302237/23387574/6ea8e902-fd2b-11e6-8410-29fa4d12a149.png)
