### PR TITLE
Revert "Fixes reliable building in both mingw32 shell as Qt creator."

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -144,29 +144,25 @@ CONFIG(WITH_SCANNER) {
 
 win32 {
 
-    # QMAKE_HOST.arch is unreliable, will allways report 32bit if mingw32 shell is run.
-    # Obtaining arch through uname should be reliable. This also fixes building the project in Qt creator without changes.
-    MSYS_HOST_ARCH = $$system(uname -a | grep -o "x86_64")
-
-    # Even if host is 64bit, we are building win32 spec, so mingw path should allways be "/mingw32"
-    MSYS_MINGW_PATH=/mingw32
-    BOOST_MINGW_PATH=$$MSYS_MINGW_PATH/boost
-
     # Win64 Host settings
-    contains(MSYS_HOST_ARCH, x86_64) {
+    contains(QMAKE_HOST.arch, x86_64) {
         message("Host is 64bit")
-        MSYS_PATH=c:/msys64/mingw32
+        MSYS_PATH=c:/msys64/mingw64
+	MSYS_MINGW_PATH=/mingw64
 
         # boost root path
-        BOOST_PATH=$$MSYS_PATH/boost
+        BOOST_PATH=c:/msys64/mingw64/boost
+	BOOST_MINGW_PATH=/mingw64/boost
 
     # WIN32 Host settings
     } else {
         message("Host is 32bit")
         MSYS_PATH=c:/msys32/mingw32
+	MSYS_MING_PATH=/mingw32
 
         # boost root path
-        BOOST_PATH=$$MSYS_PATH/boost
+        BOOST_PATH=c:/msys32/mingw32/boost
+	BOOST_MINGW_PATH=/mingw32/boost
 
     }
 


### PR DESCRIPTION
This reverts commit 630a852669118b8dab86ee9a311caf770e878124.

We can't use the official mingw binaries from Qt because it causes random crashes when combined with custom built boost. Therefore we use Qt built from source instead.  

630a852669118b8dab86ee9a311caf770e878124 can be reapplied after beta2 with appropriate exceptions for buildbot/official builds. 