### PR TITLE
Fixed missing translations and updated files

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -157,7 +157,7 @@ Rectangle {
 
         Label {
             id: unlockedBalanceLabel
-            text: qsTr("Unlocked balance")
+            text: qsTr("Unlocked balance") + translationManager.emptyString
             anchors.left: parent.left
             anchors.leftMargin: 50
             tipText: qsTr("Test tip 2<br/><br/>line 2") + translationManager.emptyString

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -42,8 +42,9 @@ Rectangle {
     property Item currentView
     property Item previousView
     property bool basicMode : false
-    property string balanceLabelText: qsTr("Balance")
+    property string balanceLabelText: qsTr("Balance") + translationManager.emptyString
     property string balanceText
+    property string unlockedBalanceLabelText: qsTr("Unlocked Balance") + translationManager.emptyString
     property string unlockedBalanceText
 
     property Transfer transferView: Transfer { }
@@ -239,6 +240,7 @@ Rectangle {
                 }
 
                 Text {
+                    id: availableBalanceLabel
                     width: 116
                     height: 20
                     font.family: "Arial"
@@ -248,7 +250,7 @@ Rectangle {
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignBottom
                     color: "#535353"
-                    text: qsTr("Unlocked Balance:")
+                    text: root.unlockedBalanceLabelText + ":"
                 }
 
                 Text {

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -150,7 +150,7 @@ Rectangle {
         shadowPressedColor: "#B32D00"
         releasedColor: "#FF6C3C"
         pressedColor: "#FF4304"
-        text: qsTr("Add")
+        text: qsTr("Add") + translationManager.emptyString
         enabled: checkInformation(addressLine.text, paymentIdLine.text, appWindow.persistentSettings.testnet)
 
         onClicked: {

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -57,7 +57,7 @@ Rectangle {
         anchors.top: newEntryText.bottom
         anchors.leftMargin: 17
         anchors.topMargin: 17
-        text: qsTr("Address")
+        text: qsTr("Address") + translationManager.emptyString
         fontSize: 14
         tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
@@ -158,11 +158,11 @@ Rectangle {
                 informationPopup.title = qsTr("Error") + translationManager.emptyString;
                 // TODO: check currentWallet.addressBook.errorString() instead.
                 if(currentWallet.addressBook.errorCode() === AddressBook.Invalid_Address)
-                     informationPopup.text  = qsTr("Invalid address")
+                     informationPopup.text  = qsTr("Invalid address") + translationManager.emptyString
                 else if(currentWallet.addressBook.errorCode() === AddressBook.Invalid_Payment_Id)
                      informationPopup.text  = currentWallet.addressBook.errorString()
                 else
-                     informationPopup.text  = qsTr("Can't create entry")
+                     informationPopup.text  = qsTr("Can't create entry") + translationManager.emptyString
 
                 informationPopup.onCloseCallback = null
                 informationPopup.open();

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -241,7 +241,7 @@ Rectangle {
                 shadowPressedColor: "#B32D00"
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
-                text: qsTr("Generate")
+                text: qsTr("Generate") + translationManager.emptyString;
                 anchors.right: parent.right
                 onClicked: {
                     appWindow.persistentSettings.payment_id = appWindow.currentWallet.generatePaymentId();
@@ -379,7 +379,7 @@ Rectangle {
             id: qrMenu
             title: "QrCode"
             MenuItem {
-               text: qsTr("Save As")
+               text: qsTr("Save As") + translationManager.emptyString;
                onTriggered: qrFileDialog.open()
             }
         }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -117,7 +117,7 @@ Rectangle {
                 shadowPressedColor: "#B32D00"
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
-                text: qsTr("Show seed")
+                text: qsTr("Show seed") + translationManager.emptyString
                 Layout.alignment: Qt.AlignRight
                 onClicked: {
                     settingsPasswordDialog.open();
@@ -225,7 +225,7 @@ Rectangle {
                 Layout.preferredWidth:  200
                 Layout.fillWidth: true
                 text: (daemonAddress !== undefined) ? daemonAddress[0] : ""
-                placeholderText: qsTr("Hostname / IP")
+                placeholderText: qsTr("Hostname / IP") + translationManager.emptyString
             }
 
 
@@ -234,7 +234,7 @@ Rectangle {
                 Layout.preferredWidth: 100
                 Layout.fillWidth: true
                 text: (daemonAddress !== undefined) ? daemonAddress[1] : "18081"
-                placeholderText: qsTr("Port")
+                placeholderText: qsTr("Port") + translationManager.emptyString
             }
         }
 
@@ -253,7 +253,7 @@ Rectangle {
                 Layout.preferredWidth:  100
                 Layout.fillWidth: true
                 text: persistentSettings.daemonUsername
-                placeholderText: qsTr("Username")
+                placeholderText: qsTr("Username") + translationManager.emptyString
             }
 
 
@@ -262,7 +262,7 @@ Rectangle {
                 Layout.preferredWidth: 100
                 Layout.fillWidth: true
                 text: persistentSettings.daemonPassword
-                placeholderText: qsTr("Password")
+                placeholderText: qsTr("Password") + translationManager.emptyString
                 echoMode: TextInput.Password
             }
 
@@ -400,7 +400,7 @@ Rectangle {
         id: daemonConsolePopup
         height:500
         width:800
-        title: qsTr("Daemon log")
+        title: qsTr("Daemon log") + translationManager.emptyString
         onAccepted: {
             close();
         }

--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -192,7 +192,7 @@ Rectangle {
 
                 FileDialog {
                     id: signFileDialog
-                    title: "Please choose a file to sign"
+                    title: qsTr("Please choose a file to sign") + translationManager.emptyString;
                     folder: "file://"
                     nameFilters: [ "*"]
 
@@ -377,7 +377,7 @@ Rectangle {
 
                 FileDialog {
                     id: verifyFileDialog
-                    title: "Please choose a file to verify"
+                    title: qsTr("Please choose a file to verify") + translationManager.emptyString;
                     folder: "file://"
                     nameFilters: [ "*"]
 

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -41,7 +41,7 @@ Rectangle {
     signal sweepUnmixableClicked()
 
     color: "#F0EEEE"
-    property string startLinkText: "<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style><font size='2'> (</font><a href='#'>Start daemon</a><font size='2'>)</font>"
+    property string startLinkText: qsTr("<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style><font size='2'> (</font><a href='#'>Start daemon</a><font size='2'>)</font>") + translationManager.emptyString
     property bool showAdvanced: false
 
     function scaleValueToMixinCount(scaleValue) {
@@ -462,7 +462,7 @@ Rectangle {
             Label {
                 id: costLabel
                 fontSize: 14
-                text: qsTr("Transaction cost")
+                text: qsTr("Transaction cost") + translationManager.emptyString
                 anchors.right: parent.right
             }
         }
@@ -581,7 +581,7 @@ Rectangle {
     //SignTxDialog
     FileDialog {
         id: signTxDialog
-        title: "Please choose a file"
+        title: qsTr("Please choose a file") + translationManager.emptyString
         folder: "file://" +moneroAccountsDir
         nameFilters: [ "Unsigned transfers (*)"]
 
@@ -642,7 +642,7 @@ Rectangle {
     //SignTxDialog
     FileDialog {
         id: submitTxDialog
-        title: "Please choose a file"
+        title: qsTr("Please choose a file") + translationManager.emptyString
         folder: "file://" +moneroAccountsDir
         nameFilters: [ "signed transfers (*)"]
 

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -49,6 +49,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -71,11 +76,6 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="138"/>
         <source>Give this entry a name or description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
-        <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -131,28 +131,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -241,7 +231,7 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
-        <source>FILTER</source>
+        <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -455,105 +445,115 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
-        <source>Unlocked Balance:</source>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -561,27 +561,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
-        <source>Connected</source>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="54"/>
-        <source>Wrong version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
-        <source>Disconnected</source>
+        <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <source>Wrong version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -599,12 +604,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,30 +617,35 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
-        <source>LOW</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
-        <source>MEDIUM</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
-        <source>HIGH</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -703,6 +713,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
@@ -745,11 +760,6 @@
     <message>
         <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -803,144 +813,142 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>Click button to show seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -986,19 +994,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1025,12 +1039,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1044,12 +1052,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1058,232 +1066,207 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,33 +1276,58 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
-        <source>SEND</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1376,13 +1384,13 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
-        <source>Transaction key</source>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
+        <location filename="../pages/TxKey.qml" line="181"/>
+        <source>Transaction key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1427,7 +1435,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1437,11 +1445,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1481,57 +1484,62 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1543,43 +1551,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1587,47 +1595,47 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1648,27 +1656,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1686,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1686,13 +1694,13 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1701,7 +1709,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1714,25 +1722,20 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
-        <source>Welcome</source>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,199 +1743,234 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -998,6 +998,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1036,6 +1041,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1134,139 +1144,145 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,13 +1292,18 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,139 +1134,139 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,7 +1276,7 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_br.ts
+++ b/translations/monero-core_br.ts
@@ -900,132 +900,132 @@
         <translation type="vanished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Mostrar semente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Local do Daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nome da máquina / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Senha</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1039,7 @@
         <translation type="vanished">Fechar a carteira atual e abrir o assistente inicial</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fechar carteira</translation>
     </message>
@@ -1089,6 +1089,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1098,6 +1103,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1212,6 +1222,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
@@ -1293,141 +1308,147 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 Número de transações: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Taxa: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Confirmação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,7 +1478,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Nível de privacidade</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Custo da transação</translation>
     </message>

--- a/translations/monero-core_br.ts
+++ b/translations/monero-core_br.ts
@@ -900,132 +900,132 @@
         <translation type="vanished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Mostrar semente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Local do Daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Nome da máquina / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Senha</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1039,7 @@
         <translation type="vanished">Fechar a carteira atual e abrir o assistente inicial</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Fechar carteira</translation>
     </message>
@@ -1293,141 +1293,141 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Informação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 Número de transações: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Taxa: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Confirmação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,7 +1457,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Nível de privacidade</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Custo da transação</translation>
     </message>

--- a/translations/monero-core_br.ts
+++ b/translations/monero-core_br.ts
@@ -4,55 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>Adicionar novo endereço</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID do Pagamento &lt;font size=&apos;2&apos;&gt;(Opcional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;ID do Pagamento&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Um nome único utilizado na&lt;br/&gt;caderneta de endereços. Não é uma&lt;br/&gt;transferência de informação enviada&lt;br/&gt;durante a transferência</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
-        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>Descrição &lt;font size=&apos;2&apos;&gt;(Banco de dados local)&lt;/font&gt;</translation>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">Erros</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
+        <translation type="vanished">Descrição &lt;font size=&apos;2&apos;&gt;(Banco de dados local)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>ADICIONAR</translation>
+        <translation type="vanished">ADICIONAR</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>ID do Pagamento</translation>
+        <translation type="vanished">ID do Pagamento</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="vanished">Descrição</translation>
     </message>
 </context>
 <context>
@@ -92,16 +132,45 @@
     </message>
 </context>
 <context>
-    <name>DaemonProgress</name>
+    <name>DaemonConsole</name>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation>Sincronizando blocos %1/%2</translation>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="87"/>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonManagerDialog</name>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonProgress</name>
+    <message>
+        <source>Synchronizing blocks %1/%2</source>
+        <translation type="vanished">Sincronizando blocos %1/%2</translation>
+    </message>
+    <message>
         <source>Synchronizing blocks</source>
-        <translation>Sincronizando blocos</translation>
+        <translation type="vanished">Sincronizando blocos</translation>
     </message>
 </context>
 <context>
@@ -163,57 +232,63 @@
         <translation>&lt;b&gt;Quantidade total de pagamentos selecionados&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="181"/>
+        <location filename="../pages/History.qml" line="182"/>
+        <source>Type for incremental search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
-        <translation>Busca incremental</translation>
+        <translation type="vanished">Busca incremental</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
         <source>Search transfers for a given string</source>
-        <translation>Procurar por caracteres especificos nas transferências</translation>
+        <translation type="vanished">Procurar por caracteres especificos nas transferências</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="194"/>
         <source>Type search string</source>
-        <translation>Digite os caracteres especificos a serem procurados</translation>
+        <translation type="vanished">Digite os caracteres especificos a serem procurados</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="234"/>
+        <location filename="../pages/History.qml" line="222"/>
         <source>Date from</source>
         <translation>Data a partir de</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="236"/>
-        <location filename="../pages/History.qml" line="261"/>
-        <location filename="../pages/History.qml" line="343"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="224"/>
+        <location filename="../pages/History.qml" line="249"/>
+        <location filename="../pages/History.qml" line="331"/>
+        <location filename="../pages/History.qml" line="366"/>
+        <location filename="../pages/History.qml" line="398"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="259"/>
-        <location filename="../pages/History.qml" line="408"/>
+        <location filename="../pages/History.qml" line="247"/>
+        <location filename="../pages/History.qml" line="396"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="285"/>
         <source>FILTER</source>
-        <translation>FILTRAR</translation>
+        <translation type="vanished">FILTRAR</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="322"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Advanced filtering</source>
         <translation>Filtragem avançada</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="341"/>
+        <location filename="../pages/History.qml" line="329"/>
         <source>Type of transaction</source>
         <translation>Tipo de transação</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="364"/>
         <source>Amount from</source>
         <translation>Quantidade a partir de</translation>
     </message>
@@ -221,53 +296,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation>ID da Transação:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>ID do Pagamento:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation>Chave da Transação:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation>Observação sobre a Transação:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="66"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>Sem mais resultados</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="97"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>Altura de bloco:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>Taxa</translation>
     </message>
@@ -275,78 +370,120 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>Saldo desbloqueado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
         <source>T</source>
-        <translation>T</translation>
+        <translation type="vanished">T</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>Receber</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>Verificar pagamento</translation>
+        <translation type="vanished">Verificar pagamento</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>Histórico</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
         <source>Sign/verify</source>
         <translation>Assinar/Verificar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="395"/>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>Preferências</translation>
     </message>
@@ -354,40 +491,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="193"/>
         <source>Balance:</source>
-        <translation>Saldo:</translation>
+        <translation type="vanished">Saldo:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="231"/>
         <source>Unlocked Balance:</source>
-        <translation>Saldo desbloqueado:</translation>
+        <translation type="vanished">Saldo desbloqueado:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Versão incorreta</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Estado de conexão inválido</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Estado da rede</translation>
     </message>
@@ -395,17 +653,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="68"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>Por favor digite a senha da carteira</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="143"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
+        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="158"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -413,66 +676,175 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>BAIXA</translation>
+        <translation type="vanished">BAIXA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>MÉDIA</translation>
+        <translation type="vanished">MÉDIA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>ALTA</translation>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProgressBar</name>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
+        <source>Synchronizing blocks</source>
+        <translation type="unfinished">Sincronizando blocos</translation>
     </message>
 </context>
 <context>
     <name>Receive</name>
     <message>
-        <location filename="../pages/Receive.qml" line="56"/>
+        <location filename="../pages/Receive.qml" line="63"/>
         <source>Invalid payment ID</source>
         <translation>ID do Pagamento inválida</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="100"/>
+        <source>WARNING: no connection to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="122"/>
+        <source>in the txpool: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="129"/>
+        <source>%2 confirmations: %3 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="131"/>
+        <source>1 confirmation: %2 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="139"/>
+        <source>No transaction found yet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>Transaction found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>%1 transactions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="149"/>
+        <source> with more money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="151"/>
+        <source> with not enough money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="182"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="189"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Endereço da carteira de somente leitura mostrado aqui</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Endereço Integrado</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>Endereço Integrado da carteira de somente leitura mostrado aquii</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="162"/>
+        <location filename="../pages/Receive.qml" line="320"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="325"/>
+        <source>Tracking payments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="326"/>
+        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>ID do Pagamento</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="170"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 ou 64 caracteres hexadecimal</translation>
+        <translation type="vanished">16 ou 64 caracteres hexadecimal</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="195"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>Gerar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="209"/>
-        <location filename="../pages/Receive.qml" line="217"/>
+        <location filename="../pages/Receive.qml" line="291"/>
+        <location filename="../pages/Receive.qml" line="299"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
@@ -516,58 +888,158 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="51"/>
-        <location filename="../pages/Settings.qml" line="110"/>
         <source>Click button to show seed</source>
-        <translation>Clique no botão para mostra a semente</translation>
+        <translation type="vanished">Clique no botão para mostra a semente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
         <source>Mnemonic seed: </source>
-        <translation>Palavras da semente:</translation>
+        <translation type="vanished">Palavras da semente:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="139"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira.</translation>
+        <translation type="vanished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="152"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Mostrar semente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="182"/>
+        <location filename="../pages/Settings.qml" line="133"/>
+        <source>Manage daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="150"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="164"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Local do Daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nome da máquina / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="200"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="212"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Senha</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="238"/>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="403"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
+        <source>Error</source>
+        <translation type="unfinished">Erros</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="423"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Configurar carteira</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="251"/>
         <source>Close current wallet and open wizard</source>
-        <translation>Fechar a carteira atual e abrir o assistente inicial</translation>
+        <translation type="vanished">Fechar a carteira atual e abrir o assistente inicial</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="262"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fechar carteira</translation>
     </message>
@@ -613,8 +1085,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>ASSINAR</translation>
+        <translation type="vanished">ASSINAR</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -623,10 +1116,8 @@
         <translation>Ou arquivo:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>SELECIONAR</translation>
+        <translation type="vanished">SELECIONAR</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -652,10 +1143,8 @@
         <translation>Mensagem a ser verificada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>VERIFICAR</translation>
+        <translation type="vanished">VERIFICAR</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -663,20 +1152,19 @@
         <translation>Nome do arquivo com mensagem a ser verificada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Endereço que assina &lt;font size=&apos;2&apos;&gt;  ( Digite ou selecione da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;caderneta&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; de endereços )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Endereço que assina &lt;font size=&apos;2&apos;&gt;  ( Digite ou selecione da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;caderneta&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; de endereços )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="105"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="121"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -684,32 +1172,264 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>BAIXA</translation>
+        <translation type="vanished">BAIXA</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">MÉDIA</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>MÉDIA</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>ALTA</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="59"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="69"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Prioridade da transação</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">Erros</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">Informação</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished">
+Número de transações: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">
+Taxa: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Confirmação</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
+        <source>Wallet is not connected to daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="720"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="725"/>
+        <source>Waiting on daemon synchronization to finish</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="91"/>
@@ -717,92 +1437,103 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="108"/>
         <source>or ALL</source>
-        <translation>ou TODAS</translation>
+        <translation type="vanished">ou TODAS</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="124"/>
         <source>LOW</source>
-        <translation>BAIXA</translation>
+        <translation type="vanished">BAIXA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
         <source>MEDIUM</source>
-        <translation>MÉDIA</translation>
+        <translation type="vanished">MÉDIA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
         <source>HIGH</source>
-        <translation>ALTA</translation>
+        <translation type="vanished">ALTA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="155"/>
         <source>Privacy level</source>
-        <translation>Nível de privacidade</translation>
+        <translation type="vanished">Nível de privacidade</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="181"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Custo da transação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Endereço &lt;font size=&apos;2&apos;&gt;  ( Digite  ou selecione um da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;caderneta&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; de endereços )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Endereço &lt;font size=&apos;2&apos;&gt;  ( Digite  ou selecione um da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;caderneta&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; de endereços )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="223"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID do Pagamento &lt;font size=&apos;2&apos;&gt;( Opcional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="235"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 ou 64 caracteres hexadecimal</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="248"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( An optional description that will be saved to the local address book if entered )&lt;/font&gt;</source>
-        <translation>Descrição &lt;font size=&apos;2&apos;&gt;( Uma descrição opcional que será salva junto a caderneta de endereços local )&lt;/font&gt;</translation>
+        <translation type="vanished">Descrição &lt;font size=&apos;2&apos;&gt;( Uma descrição opcional que será salva junto a caderneta de endereços local )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="296"/>
         <source>SEND</source>
-        <translation>ENVIAR</translation>
+        <translation type="vanished">ENVIAR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation>LIMPAR NÃO MISTURÁVEL</translation>
+        <translation type="vanished">LIMPAR NÃO MISTURÁVEL</translation>
     </message>
 </context>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
         <source>You can verify that a third party made a payment by supplying:</source>
-        <translation>Você pode verificar que um terceiro realizou um pagamento informando:</translation>
+        <translation type="vanished">Você pode verificar que um terceiro realizou um pagamento informando:</translation>
+    </message>
+    <message>
+        <source> - the recipient address,</source>
+        <translation type="vanished"> - o endereço do destinatário</translation>
+    </message>
+    <message>
+        <source> - the transaction ID,</source>
+        <translation type="vanished"> - a ID da transação</translation>
+    </message>
+    <message>
+        <source> - the tx secret key supplied by the sender</source>
+        <translation type="vanished"> - a chave secreta da transação informada pelo remetente</translation>
+    </message>
+    <message>
+        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
+        <translation type="vanished">Se um pagamento foi realizado através de várias transações, cada transação deve ser checada e os resultados agregados</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="90"/>
+        <source>Verify that a third party made a payment by supplying:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="94"/>
-        <source> - the recipient address,</source>
-        <translation> - o endereço do destinatário</translation>
+        <source> - the recipient address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="98"/>
-        <source> - the transaction ID,</source>
-        <translation> - a ID da transação</translation>
+        <source> - the transaction ID</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="102"/>
-        <source> - the tx secret key supplied by the sender</source>
-        <translation> - a chave secreta da transação informada pelo remetente</translation>
+        <source> - the secret transaction key supplied by the sender</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
-        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
-        <translation>Se um pagamento foi realizado através de várias transações, cada transação deve ser checada e os resultados agregados</translation>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -821,8 +1552,22 @@
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="157"/>
+        <source>Paste tx ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="189"/>
+        <source>Paste tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transaction ID here</source>
-        <translation>ID da Transação aqui</translation>
+        <translation type="vanished">ID da Transação aqui</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="181"/>
@@ -830,14 +1575,12 @@
         <translation>Chave da Transação</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="189"/>
         <source>Transaction key here</source>
-        <translation>Chave da Transação aqui</translation>
+        <translation type="vanished">Chave da Transação aqui</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="213"/>
         <source>CHECK</source>
-        <translation>VERIFICAR</translation>
+        <translation type="vanished">VERIFICAR</translation>
     </message>
 </context>
 <context>
@@ -853,42 +1596,57 @@
         <translation>Iniciar a blockchain do Monero?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="115"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira. Você terá que confirmar a semente na próxima tela.</translation>
+        <translation type="vanished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira. Você terá que confirmar a semente na próxima tela.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="127"/>
+        <location filename="../wizard/WizardConfigure.qml" line="115"/>
+        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
+        <translation type="unfinished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardConfigure.qml" line="126"/>
         <source>Enable disk conservation mode?</source>
         <translation>Habilitar modo de conservação de espaço no disco?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="145"/>
+        <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
         <translation>Modo de conservação de espaço no disco usa menos espaço em disco porém a mesma quantidade de banda que o modo normal. Armazenar a blockchain completa ajuda a proteger a rede do Monero. Caso esteja em um dispositivo com espaço em disco limitado, esta opção é para você.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="158"/>
+        <location filename="../wizard/WizardConfigure.qml" line="157"/>
         <source>Allow background mining?</source>
         <translation>Permitir mineração em segundo plano?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="176"/>
+        <location filename="../wizard/WizardConfigure.qml" line="175"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>A mineração protege a rede do Monero e gratifica o minerador com uma pequena quantidade de Monero pelo trabalho feito. Esta opção fará com que seu computador seja utilizado para minerar Monero quando estive ocioso. A mineração será interrompida quando você voltar a utilizar o computador.</translation>
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="94"/>
         <source>A new wallet has been created for you</source>
-        <translation>Uma nova carteira foi criada para você</translation>
+        <translation type="vanished">Uma nova carteira foi criada para você</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="95"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>Essas são as suas 25 palavras da semente para sua carteira</translation>
+        <translation type="vanished">Essas são as suas 25 palavras da semente para sua carteira</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -927,97 +1685,182 @@
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Ativada</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Desativada</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>Nome da conta</translation>
+        <translation type="vanished">Nome da conta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>Semente</translation>
+        <translation type="vanished">Semente</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Caminho da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Endereço do Daemon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Restaurar da altura</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
-        <source>An overview of your Monero configuration is below:</source>
-        <translation>Segue abaixo uma visão-geral das configurações do seu Monero:</translation>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
+        <source>You’re all set up!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An overview of your Monero configuration is below:</source>
+        <translation type="vanished">Segue abaixo uma visão-geral das configurações do seu Monero:</translation>
+    </message>
+    <message>
         <source>You’re all setup!</source>
-        <translation>Tudo pronto!</translation>
+        <translation type="vanished">Tudo pronto!</translation>
     </message>
 </context>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="202"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Uma carteira com o mesmo nome já existe. Por favor mude o nome da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="337"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <source>Non-ASCII characters are not allowed in wallet path or account name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>USAR O MONERO</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">Erros</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>Este é o nome da sua carteira. Você pode mudar para outro se preferir:</translation>
+        <translation type="vanished">Este é o nome da sua carteira. Você pode mudar para outro se preferir:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>Altura de restauração</translation>
+        <translation type="vanished">Altura de restauração</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Sua carteira está armazenada em</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Por favor escolha um diretório</translation>
     </message>
@@ -1025,45 +1868,70 @@
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira. Você terá que confirmar a semente na próxima tela.</translation>
+        <translation type="vanished">É extremamente importante guardar a semente em um lugar seguro pois ela é a única informação necessária para recuperar sua carteira. Você terá que confirmar a semente na próxima tela.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Bem-vindo ao Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Por favor selecione uma das seguintes opções:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>Esta é minha primeira execução do programa, quero criar uma nova carteira</translation>
+        <translation type="vanished">Esta é minha primeira execução do programa, quero criar uma nova carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>Quero recuperar minha carteira através das 25 palavras da semente</translation>
+        <translation type="vanished">Quero recuperar minha carteira através das 25 palavras da semente</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>Quero abrir uma carteira em um arquivo</translation>
+        <translation type="vanished">Quero abrir uma carteira em um arquivo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>Por favor configure o endereço do daemon abaixo</translation>
+        <translation type="vanished">Por favor configure o endereço do daemon abaixo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1071,55 +1939,82 @@
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>Agora que sua carteira foi criada, por favor entre com uma senha para a carteira</translation>
+        <translation type="vanished">Agora que sua carteira foi criada, por favor entre com uma senha para a carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>Agora que sua carteira foi restaurada, por favor entre com uma senha para a carteira</translation>
+        <translation type="vanished">Agora que sua carteira foi restaurada, por favor entre com uma senha para a carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="138"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>Atenção: esta senha não pode ser recuperada e se você esquecê-la terá que restaurar sua carteira através da semente&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">Atenção: esta senha não pode ser recuperada e se você esquecê-la terá que restaurar sua carteira através da semente&lt;br/&gt;&lt;br/&gt;
                         Sua senha será utilizada para proteger sua carteira e confirmar ações, tenha certeza que ela é segura o suficiente.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="152"/>
         <source>Password</source>
-        <translation>Senha</translation>
+        <translation type="vanished">Senha</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="165"/>
         <source>Confirm password</source>
-        <translation>Confirme a senha</translation>
+        <translation type="vanished">Confirme a senha</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">Senha</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Confirme a senha</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="87"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>Estamos prontos para recuperar sua conta</translation>
+        <translation type="vanished">Estamos prontos para recuperar sua conta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="88"/>
         <source>Please enter your 25 word private key</source>
-        <translation>Por favor entre com as 25 palavras da semente</translation>
+        <translation type="vanished">Por favor entre com as 25 palavras da semente</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Bem-vindo</translation>
+        <translation type="vanished">Bem-vindo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Bem-vindo ao Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Por favor escolha um idioma e formato da localização</translation>
     </message>
@@ -1127,77 +2022,111 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="248"/>
-        <location filename="../main.qml" line="369"/>
-        <location filename="../main.qml" line="430"/>
-        <location filename="../main.qml" line="441"/>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="546"/>
-        <location filename="../main.qml" line="575"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="249"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Não foi possível abrir a carteira: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="336"/>
         <source>Synchronizing blocks %1 / %2</source>
-        <translation>Sincronizando blocos %1 / %2</translation>
+        <translation type="vanished">Sincronizando blocos %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="371"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">Saldo desbloqueado</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
+        <source>Waiting for daemon to start...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="401"/>
+        <source>Waiting for daemon to stop...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Não foi possível criar a transação: Versão do daemon incorreta: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="373"/>
-        <location filename="../main.qml" line="466"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Não foi possível criar a transação: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="381"/>
-        <location filename="../main.qml" line="382"/>
-        <location filename="../main.qml" line="474"/>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Sem saídas impossiveis de serem misturadas para limpar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
-        <location filename="../main.qml" line="487"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="395"/>
-        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Por favor confirme a transação:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="396"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Endereço: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="397"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
 ID do Pagamento: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="398"/>
-        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1206,31 +2135,62 @@ Amount: </source>
 Quantidade: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Taxa: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>
 
 Mixin: </source>
-        <translation>
+        <translation type="vanished">
 
 Mixin: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="401"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>
 Número de transações: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -1239,67 +2199,81 @@ Description: </source>
 Descrição: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="431"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Quantidade incorreta: aceitável vai de %1 até %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>Saldo insuficiente. Total desbloqueado: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Não foi possível enviar as moedas: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Moedas enviadas com sucesso: %1 transação(ões) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Verificação de pagamento</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Este endereço recebeu %1 monero, porém a transação ainda não foi minerada</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
         <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>Este endereço recebeu %1 monero, com %2 confirmações</translation>
+        <translation type="vanished">Este endereço recebeu %1 monero, com %2 confirmações</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="571"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Este endereço não recebeu moedas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="731"/>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Por favor aguarde...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="756"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Assistente de configuração do programa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="770"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>enviar ao mesmo destino</translation>
     </message>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
@@ -82,9 +87,8 @@
         <translation type="vanished">Beschreibung &lt;font size=&apos;2&apos;&gt;(Lokale Datenbank)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>NEU</translation>
+        <translation type="vanished">NEU</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -147,28 +151,30 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
         <source>Daemon doesn&apos;t appear to be running</source>
-        <translation>Daemon scheint nicht aktiv zu sein</translation>
+        <translation type="vanished">Daemon scheint nicht aktiv zu sein</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
         <source>Start daemon</source>
-        <translation>Starte den Deamon</translation>
+        <translation type="vanished">Starte den Deamon</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
         <source>Cancel</source>
-        <translation type="unfinished">Abbrechen</translation>
+        <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -251,6 +257,11 @@
         <translation>&lt;b&gt;Gesamtbetrag der ausgewählten Zahlungen&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
         <translation type="vanished">Inkrementelle Suche</translation>
     </message>
@@ -279,9 +290,8 @@
         <translation>bis</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="273"/>
         <source>FILTER</source>
-        <translation>FILTER</translation>
+        <translation type="vanished">FILTER</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -506,105 +516,119 @@
         <translation type="unfinished">Guthaben</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unlocked Balance:</source>
-        <translation>Verfügbares Guthaben:</translation>
+        <translation type="vanished">Verfügbares Guthaben:</translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,27 +636,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Netzwerkstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Verbunden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Falsche Version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Getrennt</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Ungültiger Verbindungsstatus</translation>
     </message>
@@ -650,12 +679,12 @@
         <translation type="unfinished">Bitte gebe dein Wallet Passwort ein:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished">Ok</translation>
     </message>
@@ -663,30 +692,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>NIEDRIG</translation>
+        <translation type="vanished">NIEDRIG</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>MITTEL</translation>
+        <translation type="vanished">MITTEL</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>HOCH</translation>
+        <translation type="vanished">HOCH</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation type="unfinished">Synchronisiere Block %1/%2</translation>
+        <translation type="obsolete">Synchronisiere Block %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished">Synchronisiere Blöcke</translation>
     </message>
@@ -754,6 +804,11 @@
         <translation type="unfinished">Schreibgeschütztes Wallet wird hier angezeigt</translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Integrierte Adresse</translation>
@@ -784,9 +839,8 @@
         <translation>Zahlungs-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="219"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 oder 64 Hexadezimal-Zeichen</translation>
+        <translation type="vanished">16 oder 64 Hexadezimal-Zeichen</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -854,24 +908,16 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>Click button to show seed</source>
-        <translation>Schlatfläche drücken um die Wiederherstellungs-Wörter einzusehen</translation>
+        <translation type="vanished">Schlatfläche drücken um die Wiederherstellungs-Wörter einzusehen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished">Falsches Passwort</translation>
     </message>
@@ -884,17 +930,17 @@
         <translation type="vanished">Es ist wichtig, dass Sie sich die Wörter notieren, da Sie damit Ihr Wallet wiederherstellen können.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Wörter anzeigen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Daemon-Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Wallet verwalten</translation>
     </message>
@@ -903,107 +949,121 @@
         <translation type="vanished">Dieses Wallet schließen und Wizard öffnen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Wallet schließen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished">Daemon verwalten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished">Starte den Deamon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished">Stoppe den Deamon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
         <source>Show log</source>
-        <translation type="unfinished">Zeige Bericht</translation>
+        <translation type="obsolete">Zeige Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Passwort</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished">Deamon Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Hostname / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
@@ -1049,8 +1109,24 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>SIGNIEREN</translation>
+        <translation type="vanished">SIGNIEREN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -1059,10 +1135,8 @@
         <translation>Oder Datei:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>AUSWÄHLEN</translation>
+        <translation type="vanished">AUSWÄHLEN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -1088,10 +1162,8 @@
         <translation>Zu verifizierende Nachricht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>VERIFIZIEREN</translation>
+        <translation type="vanished">VERIFIZIEREN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -1107,12 +1179,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1124,30 +1196,38 @@
         <translation type="vanished">NIEDRIG</translation>
     </message>
     <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">MITTEL</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">HOCH</translation>
+    </message>
+    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>MITTEL</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>HOCH</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Priorität</translation>
     </message>
@@ -1173,185 +1253,217 @@
         <translation type="vanished">oder ALLES</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
         <source>LOW (x1 fee)</source>
-        <translation type="unfinished">Niedrig (x1 Gebühr)</translation>
+        <translation type="obsolete">Niedrig (x1 Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
         <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished">Mittel (x20 Gebühr)</translation>
+        <translation type="obsolete">Mittel (x20 Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
         <source>HIGH (x166 fee)</source>
-        <translation type="unfinished">Hoch (x166 Gebühr)</translation>
+        <translation type="obsolete">Hoch (x166 Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Senden</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Bestätigung</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1360,30 +1472,25 @@ Ring size: </source>
         <translation type="vanished">Privatsphärelevel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Transaktionskosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished">Wallet ist nicht mit dem Deamon verbunden.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished">Der verbundene Deamon ist nicht mit der GUI kompatibel.
         Bitte installiere die neuste Version oder verbinde dich zu einem anderen Deamon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1392,12 +1499,12 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adresse &lt;font size=&apos;2&apos;&gt;  (Eintippen oder aus dem &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adressbuch&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; auswählen )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Zahlungs-ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 oder 64 Hexadezimalzeichen</translation>
     </message>
@@ -1406,19 +1513,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Beschreibung &lt;font size=&apos;2&apos;&gt;(Eine optionale Beschreibung die im lokalen Adressbuch gespeichert wird)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>SENDEN</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">SENDEN</translation>
     </message>
 </context>
 <context>
@@ -1469,6 +1565,11 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished">Füge tx-ID ein</translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation type="unfinished">Transaktions Schlüssel</translation>
@@ -1479,9 +1580,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
         <source>CHECK</source>
-        <translation type="unfinished">PRÜFE</translation>
+        <translation type="obsolete">PRÜFE</translation>
     </message>
 </context>
 <context>
@@ -1529,7 +1629,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1547,11 +1647,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1591,21 +1686,21 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Aktiviert</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Deaktiviert</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
@@ -1618,38 +1713,43 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Wiederherstellungs-Wörter</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Wallet-Speicherort</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Daemon-Adresse</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Wiederherstellungspunkt</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1669,43 +1769,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Ein Wallet mit diesem Namen ist bereits vorhanden. Bitte ändere den Wallet-Namen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished">Nur ASCII Zeichen sind im Walletpfad oder im Walletname erlaubt.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>VERWENDE MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1725,47 +1825,47 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Wiederherstellungspunkt</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Dein Wallet ist hier gespeichert</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Wähle einen Speicherort</translation>
     </message>
@@ -1794,27 +1894,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Willkommen zu Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Bitte wähle eine der folgenden Optionen:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1840,7 +1940,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Bitte Daemon-Adresse unten einstellen.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1870,13 +1970,13 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Passwort bestätigen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1885,7 +1985,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished">Passwort</translation>
     </message>
@@ -1906,25 +2006,24 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Bitte gib die Wiederherstellungs-Wörter ein</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Willkommen</translation>
+        <translation type="vanished">Willkommen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Willkommen zu Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Bitte wähle eine Sprache und ein Anzeigeformat.</translation>
     </message>
@@ -1932,19 +2031,19 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Wallet konnte nicht geöffnet werden: </translation>
     </message>
@@ -1953,29 +2052,29 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Synchronisiere Blöcke %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transaktion konnte nicht erstellt werden: Falsche Daemon-Version: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bitte bestätige die Transaktion:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1984,89 +2083,130 @@ Amount: </source>
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished">Beschreibung: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished">Geld erfolgreich verschickt: %1 Transaktion(en)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished">Zahlungscheck</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished">Diese Adresse hat %1 Monero empfangen, aber die Transaktion wurde noch nicht geminet.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="572"/>
-        <source>This address received %1 monero, with %2 confirmations</source>
-        <translation type="unfinished">Diese Adresse hat %1 Monero empfangen, mit %2 Bestätigungen</translation>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished">Stoppe den Deamon</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This address received %1 monero, with %2 confirmations</source>
+        <translation type="obsolete">Diese Adresse hat %1 Monero empfangen, mit %2 Bestätigungen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished">Die Adresse hat nichts empfangen.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Transaktion konnte nicht erstellt werden: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">Verfügbares Guthaben</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished">Warte auf Start des Deamons...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished">Warte bis der Demon beendet wird...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Adresse: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
@@ -2079,72 +2219,65 @@ Amount: </source>
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Geld konnte nicht versendet werden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">Guthaben</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Bitte warten...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Installations - Assistent</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>an die selbe Adresse senden</translation>
     </message>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -912,12 +912,12 @@
         <translation type="vanished">Schlatfläche drücken um die Wiederherstellungs-Wörter einzusehen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished">Falsches Passwort</translation>
     </message>
@@ -930,12 +930,12 @@
         <translation type="vanished">Es ist wichtig, dass Sie sich die Wörter notieren, da Sie damit Ihr Wallet wiederherstellen können.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Wörter anzeigen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Daemon-Adresse</translation>
     </message>
@@ -949,27 +949,27 @@
         <translation type="vanished">Dieses Wallet schließen und Wizard öffnen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Wallet schließen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished">Daemon verwalten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished">Starte den Deamon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished">Stoppe den Deamon</translation>
     </message>
@@ -978,92 +978,92 @@
         <translation type="obsolete">Zeige Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Passwort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished">Deamon Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Hostname / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
@@ -1346,124 +1346,124 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Senden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Bestätigung</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1472,25 +1472,25 @@ Ringsize: </source>
         <translation type="vanished">Privatsphärelevel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Transaktionskosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished">Wallet ist nicht mit dem Deamon verbunden.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished">Der verbundene Deamon ist nicht mit der GUI kompatibel.
         Bitte installiere die neuste Version oder verbinde dich zu einem anderen Deamon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -912,12 +912,12 @@
         <translation type="vanished">Schlatfläche drücken um die Wiederherstellungs-Wörter einzusehen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished">Falsches Passwort</translation>
     </message>
@@ -930,12 +930,12 @@
         <translation type="vanished">Es ist wichtig, dass Sie sich die Wörter notieren, da Sie damit Ihr Wallet wiederherstellen können.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Wörter anzeigen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Daemon-Adresse</translation>
     </message>
@@ -949,27 +949,27 @@
         <translation type="vanished">Dieses Wallet schließen und Wizard öffnen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Wallet schließen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished">Daemon verwalten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished">Starte den Deamon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished">Stoppe den Deamon</translation>
     </message>
@@ -978,92 +978,92 @@
         <translation type="obsolete">Zeige Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Passwort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished">Deamon Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Hostname / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
@@ -1113,6 +1113,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1122,6 +1127,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1270,6 +1280,11 @@
         <translation type="obsolete">Hoch (x166 Gebühr)</translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="78"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
@@ -1346,124 +1361,130 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Senden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Bestätigung</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1472,25 +1493,25 @@ Ringsize: </source>
         <translation type="vanished">Privatsphärelevel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Transaktionskosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished">Wallet ist nicht mit dem Deamon verbunden.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished">Der verbundene Deamon ist nicht mit der GUI kompatibel.
         Bitte installiere die neuste Version oder verbinde dich zu einem anderen Deamon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -4,59 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>Aldonu novan kontakton</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>paga-ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;Betaal-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Unika uzantnomo uzita en&lt;br/&gt;la adresaron. Tio informo ne senditos a&lt;br/&gt;kun la transakcio</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
-        <translation type="obsolete">&lt;b&gt;Paga-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Unika uzantnomo uzita en&lt;br/&gt;la adresaron. Tio informo ne senditos a&lt;br/&gt;kun la transakcio</translation>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">Eraro</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>Priskribo &lt;font size=&apos;2&apos;&gt;(Loka datumbazo)&lt;/font&gt;</translation>
+        <translation type="vanished">Priskribo &lt;font size=&apos;2&apos;&gt;(Loka datumbazo)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>ALDONU</translation>
+        <translation type="vanished">ALDONU</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>Paga-ID</translation>
+        <translation type="vanished">Paga-ID</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>Priskribo</translation>
+        <translation type="vanished">Priskribo</translation>
     </message>
 </context>
 <context>
@@ -96,32 +132,57 @@
     </message>
 </context>
 <context>
+    <name>DaemonConsole</name>
+    <message>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
         <source>Daemon doesn&apos;t appear to be running</source>
-        <translation>Ŝajnas ke la demono ne funkcias</translation>
+        <translation type="vanished">Ŝajnas ke la demono ne funkcias</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
         <source>Start daemon</source>
-        <translation>Enŝaltu demonon</translation>
+        <translation type="vanished">Enŝaltu demonon</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
         <source>Cancel</source>
-        <translation>Nuligu</translation>
+        <translation type="vanished">Nuligu</translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DaemonProgress</name>
     <message>
         <source>Synchronizing blocks %1/%2</source>
-        <translation>Sinkronigado de blokoj %1/%2</translation>
+        <translation type="vanished">Sinkronigado de blokoj %1/%2</translation>
     </message>
     <message>
         <source>Synchronizing blocks</source>
-        <translation>Sinkronigado de blokoj</translation>
+        <translation type="vanished">Sinkronigado de blokoj</translation>
     </message>
 </context>
 <context>
@@ -192,6 +253,11 @@
         <translation>&lt;b&gt;Totalkvanto de selektitaj pagoj&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
         <translation type="vanished">Pliiganta serĉo</translation>
     </message>
@@ -206,7 +272,7 @@
     <message>
         <location filename="../pages/History.qml" line="182"/>
         <source>Type for incremental search...</source>
-        <translation type="vanished">Tajpu por pliiganta serĉo...</translation>
+        <translation>Tajpu por pliiganta serĉo...</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="222"/>
@@ -220,9 +286,8 @@
         <translation>Al</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="273"/>
         <source>FILTER</source>
-        <translation>FILTRU</translation>
+        <translation type="vanished">FILTRU</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -247,58 +312,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="67"/>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>Ne plu da rezultoj</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>Paga-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation>Tr ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation>Tr ŝlosilo</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation>Tr noto</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="50"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
         <source>Destinations:</source>
         <translation>Destinoj</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="99"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>Detaloj</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>Blokalteco</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>Kosto</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
@@ -306,78 +386,120 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>Disponebla saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>Sendu</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
         <source>T</source>
-        <translation>T</translation>
+        <translation type="vanished">T</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>Ricevu</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>Kontrolu pagon</translation>
+        <translation type="vanished">Kontrolu pagon</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>Historio</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
         <source>Sign/verify</source>
         <translation>Subskribu/kontrolu</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="395"/>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
         <translation>A</translation>
     </message>
@@ -385,40 +507,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="204"/>
         <source>Balance:</source>
-        <translation>Saldo:</translation>
+        <translation type="vanished">Saldo:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="242"/>
         <source>Unlocked Balance:</source>
-        <translation>Disponebla Saldo:</translation>
+        <translation type="vanished">Disponebla Saldo:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Retstatuso</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Konektita</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Malĝusta versio</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Malkonektita</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Malĝusta retstatuso</translation>
     </message>
@@ -426,22 +669,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="77"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>Bonvolu tajpi monujpasvorton</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="77"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Bonvolu tajpi monujpasvorton por:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="152"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Nuligu</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="167"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Bone</translation>
     </message>
@@ -449,30 +692,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>MALALTA</translation>
+        <translation type="vanished">MALALTA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation> MEZA</translation>
+        <translation type="vanished"> MEZA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>ALTA</translation>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation>Sinkronigado de blokoj %1/%2</translation>
+        <translation type="vanished">Sinkronigado de blokoj %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation>Sinkronigado de blokoj</translation>
     </message>
@@ -540,24 +804,43 @@
         <translation>Nurlegebla monujadreso montrata tie ĉi</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="211"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Integrita adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="220"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>Nurlegebla integrita monujadreso montrata tie ĉi</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="244"/>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>Paga-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="252"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 aŭ 64 deksesuma karaktroj</translation>
+        <translation type="vanished">16 aŭ 64 deksesuma karaktroj</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -581,7 +864,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="277"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>Generu</translation>
     </message>
@@ -625,95 +908,164 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="50"/>
-        <location filename="../pages/Settings.qml" line="117"/>
         <source>Click button to show seed</source>
-        <translation>Klaku butonon por montri semon</translation>
+        <translation type="vanished">Klaku butonon por montri semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="69"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="70"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Malĝusta pasvorto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="99"/>
         <source>Mnemonic seed: </source>
-        <translation>Mnemonika semo</translation>
+        <translation type="vanished">Mnemonika semo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="146"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
+        <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="159"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Montru semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="189"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Demonadreso</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Administru monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="258"/>
         <source>Close current wallet and open wizard</source>
-        <translation>Fermu nunan monujon kaj komencigu asistanton</translation>
+        <translation type="vanished">Fermu nunan monujon kaj komencigu asistanton</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="269"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fermu monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Administru demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="295"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Komencigu demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Haltigi demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="325"/>
         <source>Show log</source>
-        <translation>Montru logon</translation>
+        <translation type="vanished">Montru logon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="345"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Demonlogo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="198"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Gastignomo / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="207"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Pordo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Konservu</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -757,8 +1109,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>SUBSKRIBU</translation>
+        <translation type="vanished">SUBSKRIBU</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -767,10 +1140,8 @@
         <translation>Aŭ dosiero:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>SELEKTU</translation>
+        <translation type="vanished">SELEKTU</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -796,31 +1167,24 @@
         <translation>Mesaĝo por kontroli</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>KONTROLU</translation>
+        <translation type="vanished">KONTROLU</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation>Dosiernomo kun mesaĝo por kontroli</translation>
     </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="444"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Bone</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Nuligu</translation>
     </message>
@@ -828,44 +1192,268 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>MALALTA</translation>
+        <translation type="vanished">MALALTA</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">MEZA</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>MEZA</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>ALTA</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="64"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="74"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Prioritato de transakcio</translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Sendu</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="465"/>
+        <source>Transaction cost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">Eraro</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">Informo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Konfirmo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="720"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>LOW</source>
-        <translation>MALALTA</translation>
+        <translation type="vanished">MALALTA</translation>
     </message>
     <message>
         <source>MEDIUM</source>
-        <translation>MEZA</translation>
+        <translation type="vanished">MEZA</translation>
     </message>
     <message>
         <source>HIGH</source>
-        <translation>ALTA</translation>
+        <translation type="vanished">ALTA</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="91"/>
@@ -873,58 +1461,45 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="113"/>
         <source>or ALL</source>
-        <translation>aŭ ĈIO</translation>
+        <translation type="vanished">aŭ ĈIO</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="129"/>
         <source>LOW (x1 fee)</source>
-        <translation>MALALTA (x1 kosto)</translation>
+        <translation type="vanished">MALALTA (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="130"/>
         <source>MEDIUM (x20 fee)</source>
-        <translation>MEZA (x20 kosto)</translation>
+        <translation type="vanished">MEZA (x20 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="131"/>
         <source>HIGH (x166 fee)</source>
-        <translation>ALTA (x166 kosto)</translation>
+        <translation type="vanished">ALTA (x166 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="160"/>
         <source>Privacy level</source>
-        <translation>Nivelo de privateco</translation>
+        <translation type="vanished">Nivelo de privateco</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="186"/>
         <source>Transakcio cost</source>
-        <translation>Kosto de transakcio</translation>
+        <translation type="vanished">Kosto de transakcio</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="200"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="253"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional - saved to local wallet history )&lt;/font&gt;</source>
-        <translation>Priskribo &lt;font size=&apos;2&apos;&gt;( Malnepra - konservita en loka monujhistorio )&lt;/font&gt;</translation>
+        <translation type="vanished">Priskribo &lt;font size=&apos;2&apos;&gt;( Malnepra - konservita en loka monujhistorio )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="384"/>
-        <location filename="../pages/Transfer.qml" line="390"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Monujo ne konektitas al demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="393"/>
         <source>Connected daemon is not compatible with GUI. Please upgrade or connect to another daemon</source>
-        <translation>Konektita demono malkongruas kun GUI. Bonvolu plibonigi aŭ konekti al alia demono</translation>
+        <translation type="vanished">Konektita demono malkongruas kun GUI. Bonvolu plibonigi aŭ konekti al alia demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="398"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Atendanti la fino de demonsinkronigado</translation>
     </message>
@@ -933,12 +1508,12 @@
         <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer van &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; kiezen )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="228"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Paga-ID &lt;font size=&apos;2&apos;&gt;( Malnepra )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="240"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 aŭ 64 deksesuma karaktroj</translation>
     </message>
@@ -947,14 +1522,12 @@
         <translation type="vanished">Priskribo &lt;font size=&apos;2&apos;&gt;( Malnepra priskribo kiu konservitos en la loka adresaro )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="301"/>
         <source>SEND</source>
-        <translation>SENDU</translation>
+        <translation type="vanished">SENDU</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="327"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation>BALAU NEMIKSEBLA </translation>
+        <translation type="vanished">BALAU NEMIKSEBLA </translation>
     </message>
 </context>
 <context>
@@ -980,9 +1553,13 @@
         <translation> - la sekreta transakcio-ŝlosilo provizita per la sendinto</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="106"/>
         <source>If a payment had several transactions then each must must be checked and the results combined.</source>
-        <translation>Se pago havis plurajn transakciojn, ĉiu devas esti kontrolata kaj la rezultoj kombinataj.</translation>
+        <translation type="vanished">Se pago havis plurajn transakciojn, ĉiu devas esti kontrolata kaj la rezultoj kombinataj.</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -1010,14 +1587,18 @@
         <translation>Algluu Tr ŝlosilon</translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation>Transakcio ŝlosilon</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
         <source>CHECK</source>
-        <translation>KONTROLU</translation>
+        <translation type="vanished">KONTROLU</translation>
     </message>
 </context>
 <context>
@@ -1034,7 +1615,7 @@
     </message>
     <message>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon. Vi demanditos konfirmi la semon en la sekva ekrano por certigi ke vi faris bonan kopion.</translation>
+        <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon. Vi demanditos konfirmi la semon en la sekva ekrano por certigi ke vi faris bonan kopion.</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="115"/>
@@ -1063,16 +1644,27 @@
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>A new wallet has been created for you</source>
-        <translation>Nova monujon kreitas pro vi</translation>
+        <translation type="vanished">Nova monujon kreitas pro vi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>Tio ĉi estas la 25-a vorta mnemoniko por via monujo.</translation>
+        <translation type="vanished">Tio ĉi estas la 25-a vorta mnemoniko por via monujo.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1111,58 +1703,75 @@
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Ebligita</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Malebligita</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Lingvo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>Nomo de monujo</translation>
+        <translation type="vanished">Nomo de monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>Semo</translation>
+        <translation type="vanished">Semo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Vojnomo de monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Demonadreso</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testreto</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Restaŭralteco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An overview of your Monero configuration is below:</source>
-        <translation>Superrigardo de via Monera Agordo estas sube:</translation>
+        <translation type="vanished">Superrigardo de via Monera Agordo estas sube:</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
@@ -1171,50 +1780,109 @@
     </message>
     <message>
         <source>You’re all setup!</source>
-        <translation>Vi pretas!</translation>
+        <translation type="vanished">Vi pretas!</translation>
     </message>
 </context>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="153"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Monujo kun la sama nomo jam ekzistas. Bonvolu ŝangi la monujnomon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="161"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Ne-askioj karaktroj ne permesitas en la vojnomo aŭ monujnomo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="361"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>UZU MONERON</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">Eraro</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>Tiu ĉi estas la nomo de via monujo. Vi povas ŝangi ĝin en malsama nomo se vi volus:</translation>
+        <translation type="vanished">Tiu ĉi estas la nomo de via monujo. Vi povas ŝangi ĝin en malsama nomo se vi volus:</translation>
     </message>
     <message>
         <source>My account name</source>
-        <translation>Mia monujnomo</translation>
+        <translation type="vanished">Mia monujnomo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>Restaŭralteco</translation>
+        <translation type="vanished">Restaŭralteco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Via monujo konservitas en</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Bonvolu elekti dosierujon</translation>
     </message>
@@ -1223,48 +1891,73 @@
     <name>WizardMemoTextInput</name>
     <message>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon. Vi demanditos konfirmi la semon en la sekva ekrano por certigi ke vi faris bonan kopion.</translation>
+        <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon. Vi demanditos konfirmi la semon en la sekva ekrano por certigi ke vi faris bonan kopion.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
+        <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Bonvenon al Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Bonvolu elekti unu el la sekvaj opcioj:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>Tio ĉi estas mia unua fojo, mi volas krei novan monujon</translation>
+        <translation type="vanished">Tio ĉi estas mia unua fojo, mi volas krei novan monujon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>Mi volas restaŭri mian monujon el mia 25-a vortsemo.</translation>
+        <translation type="vanished">Mi volas restaŭri mian monujon el mia 25-a vortsemo.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>Mi volas malfermi monujon el dosiero</translation>
+        <translation type="vanished">Mi volas malfermi monujon el dosiero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>Bonvolu starigi demonadreson sube</translation>
+        <translation type="vanished">Bonvolu starigi demonadreson sube</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testreto</translation>
     </message>
@@ -1272,55 +1965,82 @@
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>Nun ke via monujo kreitas, bonvolu agordi pasvorton por via monujo</translation>
+        <translation type="vanished">Nun ke via monujo kreitas, bonvolu agordi pasvorton por via monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>Nun ke via monujo restaŭritas, bonvolu agordi pasvorton por via monujo</translation>
+        <translation type="vanished">Nun ke via monujo restaŭritas, bonvolu agordi pasvorton por via monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="144"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>Sciu ke tion ĉi pasvorto nerestaŭreblas kaj se vi forgesus ĝin, vi devus restaŭri vian monujon el la mnemoniksemo kiun vi ĵus recivis&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">Sciu ke tion ĉi pasvorto nerestaŭreblas kaj se vi forgesus ĝin, vi devus restaŭri vian monujon el la mnemoniksemo kiun vi ĵus recivis&lt;br/&gt;&lt;br/&gt;
                         Via pasvorto uzitos por ŝirmi vian monujon kaj konfirmi agojn. Do certiĝu ke via pasvorto sekuras sufiĉe.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="158"/>
         <source>Password</source>
-        <translation>Pasvorto</translation>
+        <translation type="vanished">Pasvorto</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="171"/>
         <source>Confirm password</source>
-        <translation>Konfirmu pasvorton</translation>
+        <translation type="vanished">Konfirmu pasvorton</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">Pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Konfirmu pasvorton</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="92"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>Ni pretas por restaŭri vian monujon</translation>
+        <translation type="vanished">Ni pretas por restaŭri vian monujon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="93"/>
         <source>Please enter your 25 word private key</source>
-        <translation>Bonvolu entajpi vian 25-an vortan privatŝlosilon</translation>
+        <translation type="vanished">Bonvolu entajpi vian 25-an vortan privatŝlosilon</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Bonvenon</translation>
+        <translation type="vanished">Bonvenon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Bonvenon al Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Bonvolu elekti lingvon kaj regionan formaton</translation>
     </message>
@@ -1328,164 +2048,273 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="233"/>
-        <location filename="../main.qml" line="374"/>
-        <location filename="../main.qml" line="435"/>
-        <location filename="../main.qml" line="446"/>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="551"/>
-        <location filename="../main.qml" line="580"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="234"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Monujo ne malfermeblas: </translation>
     </message>
     <message>
         <source>Synchronizing blocks %1 / %2</source>
-        <translation>Sinkronigado de blokoj %1 %2</translation>
+        <translation type="vanished">Sinkronigado de blokoj %1 %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nekapablas krei transakciojn: Malĝusta demonversio</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
-        <location filename="../main.qml" line="387"/>
-        <location filename="../main.qml" line="479"/>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Ne nemikseblaj eligoj por balai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
-        <location filename="../main.qml" line="493"/>
         <source>Please confirm transaction:</source>
-        <translation>Bonvolu konfirmi transakcion:</translation>
+        <translation type="vanished">Bonvolu konfirmi transakcion:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="403"/>
-        <location filename="../main.qml" line="494"/>
         <source>Amount: </source>
-        <translation>Kvanto:</translation>
+        <translation type="vanished">Kvanto:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="405"/>
         <source>Mixin: </source>
-        <translation>Enmikso: </translation>
+        <translation type="vanished">Enmikso: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="406"/>
         <source>Number of transactions: </source>
-        <translation>Kvanto da transakcioj: </translation>
+        <translation type="vanished">Kvanto da transakcioj: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
         <source>Description: </source>
-        <translation>Priskribo: </translation>
+        <translation type="vanished">Priskribo: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="436"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Kvanto malĝustas: antaŭvidita nombro de %1 al %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="527"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Mono senditas sukcese: %1 transakcio(j)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Pagkontrolo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tio ĉi adreso ricevis %1 moneron; sed la transakcio ankoraŭ ne minatas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="572"/>
         <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>Tio ĉi adreso ricevis %1 moneron, kun %2 da konfirmoj</translation>
+        <translation type="vanished">Tio ĉi adreso ricevis %1 moneron, kun %2 da konfirmoj</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Tio ĉi adreso ricevis nenion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="378"/>
-        <location filename="../main.qml" line="471"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nekapablas krei transakcion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="315"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">Disponebla saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation>Atendi por la komencado de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="320"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Atendi por haltado de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="492"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="401"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
+        <source>Please confirm transaction:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="503"/>
+        <source>
+Address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="504"/>
+        <source>
+Payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
+        <source>
+
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="509"/>
+        <source>
+
+Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished">Haltigi demonon</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Address: </source>
-        <translation>Adreso: </translation>
+        <translation type="vanished">Adreso: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
         <source>Payment ID: </source>
-        <translation>Paga-ID: </translation>
+        <translation type="vanished">Paga-ID: </translation>
     </message>
     <message>
-        <source>Amount: </source>
-        <translation>Kvanto: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="404"/>
-        <location filename="../main.qml" line="495"/>
         <source>Fee: </source>
-        <translation>Kosto: </translation>
+        <translation type="vanished">Kosto: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="447"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>Nesufiĉa da mono. Disponebla saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Mono ne sendeblas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Bonvolu atendi...</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Programagordilo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="977"/>
+        <source>Monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>Sendu al la saman destinon</translation>
     </message>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -912,12 +912,12 @@
         <translation type="vanished">Klaku butonon por montri semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation>Malĝusta pasvorto</translation>
     </message>
@@ -930,12 +930,12 @@
         <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Montru semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Demonadreso</translation>
     </message>
@@ -949,27 +949,27 @@
         <translation type="vanished">Fermu nunan monujon kaj komencigu asistanton</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Fermu monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation>Administru demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation>Komencigu demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation>Haltigi demonon</translation>
     </message>
@@ -978,92 +978,92 @@
         <translation type="vanished">Montru logon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation>Demonlogo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Gastignomo / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Pordo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Pasvorto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Konservu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1313,132 +1313,132 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Sendu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Konfirmo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
@@ -1489,8 +1489,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Priskribo &lt;font size=&apos;2&apos;&gt;( Malnepra - konservita en loka monujhistorio )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Monujo ne konektitas al demono</translation>
     </message>
@@ -1499,7 +1499,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Konektita demono malkongruas kun GUI. Bonvolu plibonigi aŭ konekti al alia demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Atendanti la fino de demonsinkronigado</translation>
     </message>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -912,12 +912,12 @@
         <translation type="vanished">Klaku butonon por montri semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Malĝusta pasvorto</translation>
     </message>
@@ -930,12 +930,12 @@
         <translation type="vanished">Ĝi gravegas noti tion ĉi ĉar ĝi estas la sola bakupo por restaŭri vian monujon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Montru semon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Demonadreso</translation>
     </message>
@@ -949,27 +949,27 @@
         <translation type="vanished">Fermu nunan monujon kaj komencigu asistanton</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fermu monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Administru demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Komencigu demonon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Haltigi demonon</translation>
     </message>
@@ -978,92 +978,92 @@
         <translation type="vanished">Montru logon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Demonlogo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Gastignomo / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Pordo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Pasvorto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Konservu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1113,6 +1113,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1122,6 +1127,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1232,6 +1242,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
@@ -1313,132 +1328,138 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Sendu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Konfirmo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
@@ -1489,8 +1510,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Priskribo &lt;font size=&apos;2&apos;&gt;( Malnepra - konservita en loka monujhistorio )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Monujo ne konektitas al demono</translation>
     </message>
@@ -1499,7 +1520,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Konektita demono malkongruas kun GUI. Bonvolu plibonigi aŭ konekti al alia demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Atendanti la fino de demonsinkronigado</translation>
     </message>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -49,6 +49,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -71,11 +76,6 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="138"/>
         <source>Give this entry a name or description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
-        <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -131,28 +131,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -241,7 +231,7 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
-        <source>FILTER</source>
+        <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -455,105 +445,115 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
-        <source>Unlocked Balance:</source>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -561,27 +561,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
-        <source>Connected</source>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="54"/>
-        <source>Wrong version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
-        <source>Disconnected</source>
+        <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <source>Wrong version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -599,12 +604,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,30 +617,35 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
-        <source>LOW</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
-        <source>MEDIUM</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
-        <source>HIGH</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -703,6 +713,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
@@ -745,11 +760,6 @@
     <message>
         <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -803,144 +813,142 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>Click button to show seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -986,19 +994,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1025,12 +1039,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1044,12 +1052,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1058,232 +1066,207 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,33 +1276,58 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
-        <source>SEND</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1376,13 +1384,13 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
-        <source>Transaction key</source>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
+        <location filename="../pages/TxKey.qml" line="181"/>
+        <source>Transaction key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1427,7 +1435,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1437,11 +1445,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1481,57 +1484,62 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1543,43 +1551,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1587,47 +1595,47 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1648,27 +1656,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1686,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1686,13 +1694,13 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1701,7 +1709,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1714,25 +1722,20 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
-        <source>Welcome</source>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,199 +1743,234 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -998,6 +998,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1036,6 +1041,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1134,139 +1144,145 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,13 +1292,18 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,139 +1134,139 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,7 +1276,7 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -897,132 +897,132 @@
         <translation type="vanished">On tärkeää, että kirjoitat tämän talteen. Tarvitset vain sen palauttaaksesi lompakon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Näytä muistintuki (seed)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Palveluprosessin osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Osoite / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Portti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Salasana</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1036,7 +1036,7 @@
         <translation type="vanished">Sulje nykyinen lompakko ja avaa asennusvelho</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Sulje lompakko</translation>
     </message>
@@ -1290,141 +1290,141 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Lähetä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Tietoa</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 Rahansiirtojen lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Siirtopalkkio:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Hyväksyntä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1454,7 +1454,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Yksityisyyden taso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Rahansiirron hinta</translation>
     </message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -4,55 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>Lisää uusi osoite</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Maksutunniste &lt;font size=&apos;2&apos;&gt;(Valinnainen)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;Maksutunniste&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Uniikki tunniste jota &lt;br/&gt;käytetään osoitekirjassa. Tunnistetta ei lähetetä&lt;br/&gt;siirron mukana</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
-        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>Kuvaus &lt;font size=&apos;2&apos;&gt;(Paikallinen tietokanta)&lt;/font&gt;</translation>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">Virhe</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
+        <translation type="vanished">Kuvaus &lt;font size=&apos;2&apos;&gt;(Paikallinen tietokanta)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>LISÄÄ</translation>
+        <translation type="vanished">LISÄÄ</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>Maksutunniste</translation>
+        <translation type="vanished">Maksutunniste</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>Lisätiedot</translation>
+        <translation type="vanished">Lisätiedot</translation>
     </message>
 </context>
 <context>
@@ -92,16 +132,45 @@
     </message>
 </context>
 <context>
-    <name>DaemonProgress</name>
+    <name>DaemonConsole</name>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation>Synkronisoidaan lohkoja %1/%2</translation>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="87"/>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonManagerDialog</name>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonProgress</name>
+    <message>
+        <source>Synchronizing blocks %1/%2</source>
+        <translation type="vanished">Synkronisoidaan lohkoja %1/%2</translation>
+    </message>
+    <message>
         <source>Synchronizing blocks</source>
-        <translation>Synkronisoidaan lohkoja</translation>
+        <translation type="vanished">Synkronisoidaan lohkoja</translation>
     </message>
 </context>
 <context>
@@ -163,58 +232,64 @@
         <translation>&lt;b&gt;Valittujen maksujen summa&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="181"/>
+        <location filename="../pages/History.qml" line="182"/>
+        <source>Type for incremental search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
-        <translation>Etsi</translation>
+        <translation type="vanished">Etsi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
         <source>Search transfers for a given string</source>
-        <translation>Etsi tiettyä merkkijonoa rahansiirroista </translation>
+        <translation type="vanished">Etsi tiettyä merkkijonoa rahansiirroista </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="194"/>
         <source>Type search string</source>
-        <translation>Kirjoita merkkijono</translation>
+        <translation type="vanished">Kirjoita merkkijono</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="234"/>
+        <location filename="../pages/History.qml" line="222"/>
         <source>Date from</source>
         <translation>Päiväys</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="236"/>
-        <location filename="../pages/History.qml" line="261"/>
-        <location filename="../pages/History.qml" line="343"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="224"/>
+        <location filename="../pages/History.qml" line="249"/>
+        <location filename="../pages/History.qml" line="331"/>
+        <location filename="../pages/History.qml" line="366"/>
+        <location filename="../pages/History.qml" line="398"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="259"/>
-        <location filename="../pages/History.qml" line="408"/>
+        <location filename="../pages/History.qml" line="247"/>
+        <location filename="../pages/History.qml" line="396"/>
         <source>To</source>
         <translation>Mihin</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="285"/>
         <source>FILTER</source>
-        <translation>SUODATIN</translation>
+        <translation type="vanished">SUODATIN</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="322"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Advanced filtering</source>
         <translatorcomment>?</translatorcomment>
         <translation>Lisäsuodatus</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="341"/>
+        <location filename="../pages/History.qml" line="329"/>
         <source>Type of transaction</source>
         <translation>Rahansiirron tyyppi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="364"/>
         <source>Amount from</source>
         <translation>Määrä</translation>
     </message>
@@ -222,53 +297,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation>Siirron tunniste (Tx ID):</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>Maksutunniste:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation>Siirron avain:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation>Siirron kommentti:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="66"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>Ei enempää tuloksia</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="97"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>Lisätietoja</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>Lohkoketjun pituus:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>Päiväys</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>Siirtopalkkio</translation>
     </message>
@@ -276,78 +371,116 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>Lukitsematon saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>Lähetä</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
-        <source>T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>Vastaannota</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>Varmenna siirto</translation>
+        <translation type="vanished">Varmenna siirto</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
         <source>Sign/verify</source>
         <translation>Allekirjoita/varmenna</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="395"/>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
@@ -355,40 +488,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="193"/>
         <source>Balance:</source>
-        <translation>Saldo:</translation>
+        <translation type="vanished">Saldo:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="231"/>
         <source>Unlocked Balance:</source>
-        <translation>Lukitsematon saldo:</translation>
+        <translation type="vanished">Lukitsematon saldo:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Yhdistetty</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Väärä versio</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Ei yhdistetty</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Virheellinen yhteys</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Verkon tila</translation>
     </message>
@@ -396,17 +650,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="68"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>Syötä lompakon salasana</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="143"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
+        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="158"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -414,66 +673,175 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>MATALA</translation>
+        <translation type="vanished">MATALA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>KESKIVERTO</translation>
+        <translation type="vanished">KESKIVERTO</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>KORKEA</translation>
+        <translation type="vanished">KORKEA</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProgressBar</name>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
+        <source>Synchronizing blocks</source>
+        <translation type="unfinished">Synkronisoidaan lohkoja</translation>
     </message>
 </context>
 <context>
     <name>Receive</name>
     <message>
-        <location filename="../pages/Receive.qml" line="56"/>
+        <location filename="../pages/Receive.qml" line="63"/>
         <source>Invalid payment ID</source>
         <translation>Virheellinen maksutunniste</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="100"/>
+        <source>WARNING: no connection to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="122"/>
+        <source>in the txpool: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="129"/>
+        <source>%2 confirmations: %3 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="131"/>
+        <source>1 confirmation: %2 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="139"/>
+        <source>No transaction found yet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>Transaction found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>%1 transactions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="149"/>
+        <source> with more money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="151"/>
+        <source> with not enough money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="182"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="189"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>ReadOnly lompakon osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Integroitu osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>ReadOnly lompakon integroitu osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="162"/>
+        <location filename="../pages/Receive.qml" line="320"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="325"/>
+        <source>Tracking payments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="326"/>
+        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>Maksutunniste</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="170"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 tai 64 heksamerkkiä</translation>
+        <translation type="vanished">16 tai 64 heksamerkkiä</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="195"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>Luo</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="209"/>
-        <location filename="../pages/Receive.qml" line="217"/>
+        <location filename="../pages/Receive.qml" line="291"/>
+        <location filename="../pages/Receive.qml" line="299"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
@@ -517,58 +885,158 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="51"/>
-        <location filename="../pages/Settings.qml" line="110"/>
         <source>Click button to show seed</source>
-        <translation>Paina nappia nähdäksesi lompakon avainlause (seed)</translation>
+        <translation type="vanished">Paina nappia nähdäksesi lompakon avainlause (seed)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
         <source>Mnemonic seed: </source>
-        <translation>Muistintuki (seed):</translation>
+        <translation type="vanished">Muistintuki (seed):</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="139"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>On tärkeää, että kirjoitat tämän talteen. Tarvitset vain sen palauttaaksesi lompakon.</translation>
+        <translation type="vanished">On tärkeää, että kirjoitat tämän talteen. Tarvitset vain sen palauttaaksesi lompakon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="152"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Näytä muistintuki (seed)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="182"/>
+        <location filename="../pages/Settings.qml" line="133"/>
+        <source>Manage daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="150"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="164"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Palveluprosessin osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Osoite / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="200"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Portti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="212"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Salasana</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="238"/>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="403"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
+        <source>Error</source>
+        <translation type="unfinished">Virhe</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="423"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Hallitse lompakkoa</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="251"/>
         <source>Close current wallet and open wizard</source>
-        <translation>Sulje nykyinen lompakko ja avaa asennusvelho</translation>
+        <translation type="vanished">Sulje nykyinen lompakko ja avaa asennusvelho</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="262"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Sulje lompakko</translation>
     </message>
@@ -614,8 +1082,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>ALLEKIRJOITA</translation>
+        <translation type="vanished">ALLEKIRJOITA</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -624,10 +1113,8 @@
         <translation>Tai tiedosto:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>VALITSE</translation>
+        <translation type="vanished">VALITSE</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -653,10 +1140,8 @@
         <translation>Viesti jonka allekirjoituksen haluat vahvistaa</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>VAHVISTA</translation>
+        <translation type="vanished">VAHVISTA</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -664,20 +1149,19 @@
         <translation>Tiedostonimi viestillä jonka haluat vahvistaa</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Allekirjoita osoitteella &lt;font size=&apos;2&apos;&gt;  ( Kirjoita tai valitse &lt;/font&gt; &lt;a href=&apos;Address&apos;&gt;Osoitekirjasta&lt;/a&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Allekirjoita osoitteella &lt;font size=&apos;2&apos;&gt;  ( Kirjoita tai valitse &lt;/font&gt; &lt;a href=&apos;Address&apos;&gt;Osoitekirjasta&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="105"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="121"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
@@ -685,32 +1169,264 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>MATALA</translation>
+        <translation type="vanished">MATALA</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">KESKIVERTO</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">KORKEA</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>KESKIVERTO</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>KORKEA</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="59"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="69"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Rahansiirron prioriteetti</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Lähetä</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">Virhe</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">Tietoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished">
+Rahansiirtojen lukumäärä:</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">
+Siirtopalkkio:</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Hyväksyntä</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
+        <source>Wallet is not connected to daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="720"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="725"/>
+        <source>Waiting on daemon synchronization to finish</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="91"/>
@@ -718,93 +1434,96 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="108"/>
         <source>or ALL</source>
-        <translation>tai KAIKKI</translation>
+        <translation type="vanished">tai KAIKKI</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="124"/>
         <source>LOW</source>
-        <translation>MATALA</translation>
+        <translation type="vanished">MATALA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
         <source>MEDIUM</source>
-        <translation>KESKIVERTO</translation>
+        <translation type="vanished">KESKIVERTO</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
         <source>HIGH</source>
-        <translation>KORKEA</translation>
+        <translation type="vanished">KORKEA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="155"/>
         <source>Privacy level</source>
-        <translation>Yksityisyyden taso</translation>
+        <translation type="vanished">Yksityisyyden taso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="181"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Rahansiirron hinta</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="223"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Maksutunniste &lt;font size=&apos;2&apos;&gt;( Valinnainen )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="235"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 tai 64 heksamerkkiä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="248"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( An optional description that will be saved to the local address book if entered )&lt;/font&gt;</source>
-        <translation>Kuvaus &lt;font size=&apos;2&apos;&gt;( Vaihtoehtoinen kuvaus joka lisätään kyseiseen osoitteeseen osoitekirjassa )&lt;/font&gt;</translation>
+        <translation type="vanished">Kuvaus &lt;font size=&apos;2&apos;&gt;( Vaihtoehtoinen kuvaus joka lisätään kyseiseen osoitteeseen osoitekirjassa )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="296"/>
         <source>SEND</source>
-        <translation>LÄHETÄ</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
-        <source>SWEEP UNMIXABLE</source>
-        <translation></translation>
+        <translation type="vanished">LÄHETÄ</translation>
     </message>
 </context>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
         <source>You can verify that a third party made a payment by supplying:</source>
-        <translation>Voit tarkistaa toisen osapuolen suorittaman maksun syöttämällä seuraavat tiedot:</translation>
+        <translation type="vanished">Voit tarkistaa toisen osapuolen suorittaman maksun syöttämällä seuraavat tiedot:</translation>
+    </message>
+    <message>
+        <source> - the recipient address,</source>
+        <translation type="vanished"> - vastaannottajan osoite,</translation>
+    </message>
+    <message>
+        <source> - the transaction ID,</source>
+        <translation type="vanished"> - rahansiirron tunniste,</translation>
+    </message>
+    <message>
+        <source> - the tx secret key supplied by the sender</source>
+        <translatorcomment>?</translatorcomment>
+        <translation type="vanished"> - rahansiirron salainen avain lähettäjältä </translation>
+    </message>
+    <message>
+        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
+        <translation type="vanished">Jos maksu koostui useista rahansiirroista, täytyy jokainen tarkistaa erikseen ja laskea yhteen</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="90"/>
+        <source>Verify that a third party made a payment by supplying:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="94"/>
-        <source> - the recipient address,</source>
-        <translation> - vastaannottajan osoite,</translation>
+        <source> - the recipient address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="98"/>
-        <source> - the transaction ID,</source>
-        <translation> - rahansiirron tunniste,</translation>
+        <source> - the transaction ID</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="102"/>
-        <source> - the tx secret key supplied by the sender</source>
-        <translatorcomment>?</translatorcomment>
-        <translation> - rahansiirron salainen avain lähettäjältä </translation>
+        <source> - the secret transaction key supplied by the sender</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
-        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
-        <translation>Jos maksu koostui useista rahansiirroista, täytyy jokainen tarkistaa erikseen ja laskea yhteen</translation>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -823,8 +1542,22 @@
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="157"/>
+        <source>Paste tx ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="189"/>
+        <source>Paste tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transaction ID here</source>
-        <translation>Rahansiirron tunniste tähän</translation>
+        <translation type="vanished">Rahansiirron tunniste tähän</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="181"/>
@@ -832,14 +1565,12 @@
         <translation>Rahansiirron avain</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="189"/>
         <source>Transaction key here</source>
-        <translation>Rahansiirron avain tähän</translation>
+        <translation type="vanished">Rahansiirron avain tähän</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="213"/>
         <source>CHECK</source>
-        <translation>TARKISTA</translation>
+        <translation type="vanished">TARKISTA</translation>
     </message>
 </context>
 <context>
@@ -855,42 +1586,57 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="115"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>On tärkeää, että kirjoitat kyseisen muistintuen (seed) talteen. Tarvitset vain sen palauttaaksesi lompakon. Sinulta kysytään sitä seuraavassa ruudussa sen varmistamiseksi, että kirjoitit sanat talteen oikein.</translation>
+        <translation type="vanished">On tärkeää, että kirjoitat kyseisen muistintuen (seed) talteen. Tarvitset vain sen palauttaaksesi lompakon. Sinulta kysytään sitä seuraavassa ruudussa sen varmistamiseksi, että kirjoitit sanat talteen oikein.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="127"/>
+        <location filename="../wizard/WizardConfigure.qml" line="115"/>
+        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
+        <translation type="unfinished">On tärkeää, että kirjoitat tämän talteen. Tarvitset vain sen palauttaaksesi lompakon.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardConfigure.qml" line="126"/>
         <source>Enable disk conservation mode?</source>
         <translation>Haluatko laittaa levynsäilytystilan päälle?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="145"/>
+        <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
         <translation>Levynsäilytystilaa käytettäessä lompakko käyttää vähemmän tilaa levyllä, mutta saman verran kaistanleveyttä kuin normaalissa tilassa. On suositeltavaa säilyttää koko lohkoketjua Moneron verkon turvaallisudeksi. Jos olet laitteella, jolla ei olisi tarpeeksi tilaa koko lohkoketjulle, tämä vaihtoehto on sopiva. </translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="158"/>
+        <location filename="../wizard/WizardConfigure.qml" line="157"/>
         <source>Allow background mining?</source>
         <translation>Sallitaanko louhiminen taustalla?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="176"/>
+        <location filename="../wizard/WizardConfigure.qml" line="175"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>Louhiminen turvaa Moneron verkon ja maksaa pienen palkkion tehdystä työstä. Tällä vaihtoehdolla annat Monero-lompakon suorittaa louhintaa tietokoneen ollessa käyttämättä ja kytkettynä virtalähteeseen. Louhinta lopetetaan automaattisesti jatkaessasi muita toimintoja.</translation>
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="94"/>
         <source>A new wallet has been created for you</source>
-        <translation>Uusi lompakko on luotu</translation>
+        <translation type="vanished">Uusi lompakko on luotu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="95"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>Tämä on 25:n sanan pituinen muistintuki lompakkoosi</translation>
+        <translation type="vanished">Tämä on 25:n sanan pituinen muistintuki lompakkoosi</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -929,97 +1675,182 @@
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Käytössä</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Poissa käytöstä</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Kieli</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>Käyttäjänimi</translation>
+        <translation type="vanished">Käyttäjänimi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>Muistintuki (Seed)</translation>
+        <translation type="vanished">Muistintuki (Seed)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Lompakon sijainti</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Palveluprosessin osoite</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Palauta tietystä lohkoketjun pituudesta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
-        <source>An overview of your Monero configuration is below:</source>
-        <translation>Alapuolella on katsaus valitsemiisi lompakon asetuksiin:</translation>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
+        <source>You’re all set up!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An overview of your Monero configuration is below:</source>
+        <translation type="vanished">Alapuolella on katsaus valitsemiisi lompakon asetuksiin:</translation>
+    </message>
+    <message>
         <source>You’re all setup!</source>
-        <translation>Kaikki on valmista!</translation>
+        <translation type="vanished">Kaikki on valmista!</translation>
     </message>
 </context>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="202"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Lompakko kyseisellä nimellä on jo olemassa. Ole hyvä ja vaihda lompakon nimi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="337"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <source>Non-ASCII characters are not allowed in wallet path or account name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>KÄYTÄ MONEROA</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">Virhe</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>Tämä on lompakkosi nimi. Voit vaihtaa sen uuteen nimeen jos haluat:</translation>
+        <translation type="vanished">Tämä on lompakkosi nimi. Voit vaihtaa sen uuteen nimeen jos haluat:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>Palauta tietystä lohkoketjun pituudesta</translation>
+        <translation type="vanished">Palauta tietystä lohkoketjun pituudesta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Lompakkosi on säilytetty kyseisessä kansiossa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Valitse tiedostopolku</translation>
     </message>
@@ -1027,45 +1858,70 @@
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>On tärkeää, että kirjoitat kyseisen muistintuen (seed) talteen. Tarvitset vain sen palauttaaksesi lompakon. Sinulta kysytään sitä seuraavassa ruudussa sen varmistamiseksi, että kirjoitit sanat talteen oikein.</translation>
+        <translation type="vanished">On tärkeää, että kirjoitat kyseisen muistintuen (seed) talteen. Tarvitset vain sen palauttaaksesi lompakon. Sinulta kysytään sitä seuraavassa ruudussa sen varmistamiseksi, että kirjoitit sanat talteen oikein.</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Tervetuloa käyttämään Moneroa!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Valitse jokin seuraavista vaihtoehdoista:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>Tämä on ensimmäinen kertani, haluan luoda uuden käyttäjän</translation>
+        <translation type="vanished">Tämä on ensimmäinen kertani, haluan luoda uuden käyttäjän</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>Haluan palauttaa lompakon 25:n sanan muistintuella (seed)</translation>
+        <translation type="vanished">Haluan palauttaa lompakon 25:n sanan muistintuella (seed)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>Haluan avata lompakon tiedostosta</translation>
+        <translation type="vanished">Haluan avata lompakon tiedostosta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>Valitse palveluprosessin osoite alapuolella.</translation>
+        <translation type="vanished">Valitse palveluprosessin osoite alapuolella.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation></translation>
     </message>
@@ -1073,55 +1929,82 @@
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>Nyt kun lompakkosi on luotu, aseta sille salasana</translation>
+        <translation type="vanished">Nyt kun lompakkosi on luotu, aseta sille salasana</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>Nyt kun lompakkosi on palautettu, aseta sille salasana</translation>
+        <translation type="vanished">Nyt kun lompakkosi on palautettu, aseta sille salasana</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="138"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>Huomioi, että tätä salasanaa ei voida palauttaa sen kadottaessa. Jos unohdat salanasasi, joudut palauttamaan lompakon muistintuella (seed), joka sinulle on juuri annettu&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">Huomioi, että tätä salasanaa ei voida palauttaa sen kadottaessa. Jos unohdat salanasasi, joudut palauttamaan lompakon muistintuella (seed), joka sinulle on juuri annettu&lt;br/&gt;&lt;br/&gt;
                         Salasanallasi turvataan lompakko ja vahvistetaan toimia, pidä huolta siitä että salasanasi on tarpeeksi vahva.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="152"/>
         <source>Password</source>
-        <translation>Salasana</translation>
+        <translation type="vanished">Salasana</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="165"/>
         <source>Confirm password</source>
-        <translation>Vahvista salasana</translation>
+        <translation type="vanished">Vahvista salasana</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">Salasana</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Vahvista salasana</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="87"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>Valmiina palauttamaan käyttäjä</translation>
+        <translation type="vanished">Valmiina palauttamaan käyttäjä</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="88"/>
         <source>Please enter your 25 word private key</source>
-        <translation>Kirjoita 25:n sanan muistintuki (seed)</translation>
+        <translation type="vanished">Kirjoita 25:n sanan muistintuki (seed)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Tervetuloa</translation>
+        <translation type="vanished">Tervetuloa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Tervetuloa käyttämään Moneroa!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Valitse kieli ja alueellinen muoto.</translation>
     </message>
@@ -1129,77 +2012,111 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="248"/>
-        <location filename="../main.qml" line="369"/>
-        <location filename="../main.qml" line="430"/>
-        <location filename="../main.qml" line="441"/>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="546"/>
-        <location filename="../main.qml" line="575"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="249"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Lompakkoa ei voitu avata:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="336"/>
         <source>Synchronizing blocks %1 / %2</source>
-        <translation>Synkronisoidaan lohkoja %1 / %2</translation>
+        <translation type="vanished">Synkronisoidaan lohkoja %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="371"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">Lukitsematon saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
+        <source>Waiting for daemon to start...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="401"/>
+        <source>Waiting for daemon to stop...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Rahansiirtoa ei onnistuttu tekemään: Palveluprosessin versio on väärä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="373"/>
-        <location filename="../main.qml" line="466"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Rahansiirtoa ei onnistuttu tekemään:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="381"/>
-        <location filename="../main.qml" line="382"/>
-        <location filename="../main.qml" line="474"/>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
-        <location filename="../main.qml" line="487"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Hyväksyntä</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="395"/>
-        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Vahvista rahansiirto:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="396"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Osoite:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="397"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
 Maksutunniste:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="398"/>
-        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1208,29 +2125,54 @@ Amount: </source>
 Määrä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Siirtopalkkio:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
+        <location filename="../main.qml" line="507"/>
         <source>
 
-Mixin: </source>
-        <translation></translation>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="401"/>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>
 Rahansiirtojen lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -1239,67 +2181,81 @@ Description: </source>
 Kuvaus:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="431"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Määrä on virheellinen: odotettiin numeroa %1 :n ja %2 :n välillä</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>riittämättömät varat. Lukitsematon saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Rahansiirtoa ei voitu suorittaa:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Tietoa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Rahat lähetettiin onnistuneesti: %1  rahansiirto(a)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Maksun tarkistus</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tähän osoitteeseen on saapunut %1 Moneroa, mutta rahansiirtoa ei ole vielä lisätty lohkoon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
         <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>Tähän osoitteeseen on saapunut %1 Moneroa, vahvistuksien määrä: %2</translation>
+        <translation type="vanished">Tähän osoitteeseen on saapunut %1 Moneroa, vahvistuksien määrä: %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="571"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Tähän osoitteeseen ei ole saapunut mitään</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="731"/>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Odota...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="756"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Sovelluksen asetusvelho</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="770"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>lähetä samaan osoitteeseen</translation>
     </message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -897,132 +897,132 @@
         <translation type="vanished">On tärkeää, että kirjoitat tämän talteen. Tarvitset vain sen palauttaaksesi lompakon.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Näytä muistintuki (seed)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Palveluprosessin osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Osoite / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Portti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Salasana</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1036,7 +1036,7 @@
         <translation type="vanished">Sulje nykyinen lompakko ja avaa asennusvelho</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Sulje lompakko</translation>
     </message>
@@ -1086,6 +1086,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1095,6 +1100,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1209,6 +1219,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Määrä</translation>
@@ -1290,141 +1305,147 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Lähetä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Tietoa</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 Rahansiirtojen lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Siirtopalkkio:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Hyväksyntä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1454,7 +1475,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Yksityisyyden taso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Rahansiirron hinta</translation>
     </message>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -49,6 +49,11 @@
         <translation>Description &lt;font size=&apos;2&apos;&gt;(Facultatif)&lt;/font&gt;</translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation>Erreur</translation>
@@ -78,9 +83,8 @@
         <translation>Donner un nom ou une description pour cette entrée</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>AJOUTER</translation>
+        <translation type="vanished">AJOUTER</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -143,29 +147,39 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
         <source>Daemon doesn&apos;t appear to be running</source>
-        <translation>Le démon semble ne pas être démarré</translation>
+        <translation type="vanished">Le démon semble ne pas être démarré</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
         <source>Start daemon</source>
-        <translation>Démarrer démon</translation>
+        <translation type="vanished">Démarrer démon</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
         <source>Cancel</source>
-        <translation>Annuler</translation>
+        <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
         <source>Daemon startup flags</source>
-        <translation>Options de démarrage</translation>
+        <translation type="vanished">Options de démarrage</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
         <source>(optional)</source>
-        <translation>(facultatif)</translation>
+        <translation type="vanished">(facultatif)</translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -276,8 +290,12 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>FILTER</source>
-        <translation>FILTRER</translation>
+        <translation type="vanished">FILTRER</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -502,105 +520,119 @@
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unlocked Balance:</source>
-        <translation>Solde débloqué :</translation>
+        <translation type="vanished">Solde débloqué :</translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation>Extraction minière en solo</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation>(disponible uniquement pour les démons locaux)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation>L&apos;extraction minière aide le réseau Monero à augmenter sa robustesse.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation>Plus il y en a, plus il est difficile d&apos;attaquer le réseau.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation>La mine vous donne aussi une petite chance de gagner des Moneros.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation>Votre ordinateur va chercher des solutions de bloc Monero.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation>Si vous trouvez un bloc, vous obtiendrez la récompense associée.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation>Threads CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation>Gérer le mineur</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation>Erreur lors du démarrage de l&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Impossible de démarrer l&apos;extraction minière.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>L&apos;extraction minière n&apos;est disponible que pour les démons locaux. Démarrez un démon local pour pouvoir l&apos;utiliser.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation>Statut : pas d&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation>Extraction minière à %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation>Pas d&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation>Statut :</translation>
     </message>
@@ -608,27 +640,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Connecté</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Mauvaise version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Déconnecté</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>État de connexion invalide</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>État du réseau</translation>
     </message>
@@ -646,12 +683,12 @@
         <translation>Entrez le mot de passe du portefeuille pour :&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -659,30 +696,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>BAS</translation>
+        <translation type="vanished">BAS</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>MOYEN</translation>
+        <translation type="vanished">MOYEN</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>HAUT</translation>
+        <translation type="vanished">HAUT</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation>Synchronisation des blocs %1/%2</translation>
+        <translation type="vanished">Synchronisation des blocs %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronisation des blocs</translation>
     </message>
@@ -750,6 +808,11 @@
         <translation>Adresse du portefeuille LectureSeule affichée ici</translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Adresse intégrée</translation>
@@ -795,9 +858,8 @@
         <translation>ID de paiement</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="219"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 ou 64 caractères hexadécimaux</translation>
+        <translation type="vanished">16 ou 64 caractères hexadécimaux</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="244"/>
@@ -850,10 +912,8 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>Click button to show seed</source>
-        <translation>Cliquez sur le bouton pour afficher la graine</translation>
+        <translation type="vanished">Cliquez sur le bouton pour afficher la graine</translation>
     </message>
     <message>
         <source>Mnemonic seed: </source>
@@ -864,133 +924,153 @@
         <translation type="vanished">Il est très important de l&apos;écrire sur papier car c&apos;est la seule sauvegarde dont vous aurez besoin pour votre portefeuille.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation>Les portefeuilles en vue seule n&apos;ont pas de graine mnémonique</translation>
+        <translation type="vanished">Les portefeuilles en vue seule n&apos;ont pas de graine mnémonique</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation>Créer portefeuille vue seule</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
         <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation>Il est très important de l&apos;écrire sur papier et de le garder secret. C&apos;est tout ce dont vous aurez besoin pour restaurer votre portefeuille.</translation>
+        <translation type="vanished">Il est très important de l&apos;écrire sur papier et de le garder secret. C&apos;est tout ce dont vous aurez besoin pour restaurer votre portefeuille.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Montrer la graine</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Gérer le démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Lancer démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Arrêter démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
         <source>Show log</source>
-        <translation>Montrer le journal</translation>
+        <translation type="vanished">Montrer le journal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
         <source>Status</source>
-        <translation>Statut</translation>
+        <translation type="vanished">Statut</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation>Options de démarrage</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Adresse du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nom d&apos;hôte / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation>Réglages d&apos;agencement</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation>Décorations personnalisées</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation>Niveau journal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation>Version de l&apos;interface graphique : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation>Version de Monero incorporée : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Journal du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Mauvais mot de passe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Gérer le portefeuille</translation>
     </message>
@@ -999,7 +1079,7 @@
         <translation type="vanished">Fermer le portefeuille courant et ouvrir l&apos;assistant</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fermer</translation>
     </message>
@@ -1045,8 +1125,24 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>SIGNER</translation>
+        <translation type="vanished">SIGNER</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -1055,10 +1151,8 @@
         <translation>Ou un fichier :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>SÉLECTIONNER</translation>
+        <translation type="vanished">SÉLECTIONNER</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -1084,10 +1178,8 @@
         <translation>Message à vérifier</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>VÉRIFIER</translation>
+        <translation type="vanished">VÉRIFIER</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -1107,12 +1199,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1124,241 +1216,305 @@
         <translation type="vanished">BAS</translation>
     </message>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>NORMAL</source>
-        <translation>NORMAL</translation>
+        <translation type="vanished">NORMAL</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">MOYEN</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">HAUT</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>MOYEN</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>HAUT</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation>Erreur OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
         <source>Privacy level (ring size %1)</source>
-        <translation>Niveau de confidentialité (taille du cercle %1)</translation>
+        <translation type="vanished">Niveau de confidentialité (taille du cercle %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Priorité de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
         <source>ALL</source>
-        <translation>TOUT</translation>
+        <translation type="vanished">TOUT</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
         <source>LOW (x1 fee)</source>
-        <translation>BAS (frais x1)</translation>
+        <translation type="vanished">BAS (frais x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
         <source>MEDIUM (x20 fee)</source>
-        <translation>MOYEN (frais x20)</translation>
+        <translation type="vanished">MOYEN (frais x20)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
         <source>HIGH (x166 fee)</source>
-        <translation>HAUT (frais x166)</translation>
+        <translation type="vanished">HAUT (frais x166)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adresse &lt;font size=&apos;2&apos;&gt;  ( Collez  ou sélectionnez dans le &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Carnet d&apos;adresses&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adresse &lt;font size=&apos;2&apos;&gt;  ( Collez  ou sélectionnez dans le &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Carnet d&apos;adresses&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
         <source>QRCODE</source>
-        <translation>CODE QR</translation>
+        <translation type="vanished">CODE QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
         <source>RESOLVE</source>
-        <translation>RÉSOUDRE</translation>
+        <translation type="vanished">RÉSOUDRE</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Pas d&apos;adresse valide trouvée à cette adresse OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresse trouvée, mais les signatures DNSSEC n&apos;ont pas pu être vérifiées, donc cette adresse pourrait avoit été falsifiée</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Pas d&apos;adresse valide trouvée à cette adresse OpenAlias, mais les signatures DNSSEC n&apos;ont pas pu être vérifiées, donc ceci pourrait être avoir été falsifié</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation>Erreur interne</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation>Pas d&apos;adresse trouvée</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Description &lt;font size=&apos;2&apos;&gt;( Facultatif )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation>Enregistré dans l&apos;historique du portefeuille local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Envoyer</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation>créer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation>signer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation>Soumettre fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation>Scan dépenses</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation>Les sorties dépensées ont été rescannées avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Impossible de charger une transaction non signée : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transaction #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation>
 Destinataire : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation>
 identifiant de paiement : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>
 Ring size: </source>
-        <translation>
+        <translation type="vanished">
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Impossible de soumettre la transaction : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation>Argent envoyé avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Le portefeuille n&apos;est pas connecté au démon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Le démon connecté n&apos;est pas compatible avec l&apos;interface graphique. 
 Veuillez mettre à jour ou vous connecter à un autre démon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Attente de la fin de la synchronisation avec le démon</translation>
     </message>
@@ -1388,7 +1544,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Niveau de confidentialité</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Coût de transaction</translation>
     </message>
@@ -1397,12 +1553,12 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adresse &lt;font size=&apos;2&apos;&gt;  ( Entrez  ou sélectionnez dans le &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Carnet d&apos;adresses&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID de paiement &lt;font size=&apos;2&apos;&gt;( Facultatif )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 ou 64 caractères hexadécimaux</translation>
     </message>
@@ -1411,19 +1567,16 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Description &lt;font size=&apos;2&apos;&gt;( Une description facultative qui sera sauvegardée dans le carnet d&apos;adresses local )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>ENVOYER</translation>
+        <translation type="vanished">ENVOYER</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
         <source>Advanced</source>
-        <translation>Avancé</translation>
+        <translation type="vanished">Avancé</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation>NON MÉLANGEABLES</translation>
+        <translation type="vanished">NON MÉLANGEABLES</translation>
     </message>
 </context>
 <context>
@@ -1499,6 +1652,11 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation>Coller la clé de transaction</translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transaction ID here</source>
         <translation type="vanished">ID de transaction ici</translation>
     </message>
@@ -1512,9 +1670,8 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Clé de transaction ici</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
         <source>CHECK</source>
-        <translation>VÉRIFIER</translation>
+        <translation type="vanished">VÉRIFIER</translation>
     </message>
 </context>
 <context>
@@ -1562,7 +1719,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation>Créer portefeuille vue seule</translation>
     </message>
@@ -1583,9 +1740,8 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation>Créer un nouveau portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
-        <translation>Voici la graine mnémonique de 25 mots pour votre portefeuille</translation>
+        <translation type="vanished">Voici la graine mnémonique de 25 mots pour votre portefeuille</translation>
     </message>
 </context>
 <context>
@@ -1624,21 +1780,21 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Activé</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
@@ -1651,39 +1807,44 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Graine</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation>Nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation>Graine de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Chemin du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Adresse du démon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Hauteur de réstoration</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
         <translation>Détails du nouveau portefeuille :</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
@@ -1702,44 +1863,44 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Un portefeuille avec le même nom existe déjà. Veuillez changer le nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Les caractères non ASCII ne sont pas autorisés dans le chemin du portefeuille ou le nom du compte</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>UTILISER MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation>Créer un portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation>Succès</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Le portefeuille en vue seule a été créé. Vous pouvez l&apos;ouvrir en fermant le portefeuille actuel, puis en cliquant sur l&apos;option &quot;Ouvrir un fichier portefeuille&quot; et en sélectionnant le portefeuille en vue seule dans : 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation>Abandonner</translation>
     </message>
@@ -1755,47 +1916,47 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Hauteur de restoration</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation>Nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation>Restaurer à partir de la graine</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation>Restaurer à partir des clés</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation>Adresse du compte (publique)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation>Clé d&apos;audit (privée)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation>Clé de dépense (privée)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation>Hauteur de restoration (facultatif)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Votre portefeuille est stocké dans</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Veuillez choisir un répertoire</translation>
     </message>
@@ -1820,27 +1981,27 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Bienvenue dans Monero !</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Veuillez sélectionner une des options suivantes :</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation>Créer un nouveau portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Restaurer un portefeuille à partir des clés ou de la graine mnémonique</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation>Ouvrir un fichier portefeuille</translation>
     </message>
@@ -1866,7 +2027,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Veuillez configurer l&apos;adresse du démon ci-dessous.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1896,13 +2057,13 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Confirmer le mot de passe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation>Mettre un mot de passe à votre portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>Note : ce mot de passe ne pourra pas être recupéré. Si vous l&apos;oubliez vous devrez restaurer votre portefeuille avec sa graine mnémonique de 25 mots.&lt;br/&gt;&lt;br/&gt;
@@ -1912,7 +2073,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
@@ -1933,25 +2094,28 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Veuillez entrer votre clé privée de 25 mots</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
         <source>Restore wallet</source>
         <translation>Restaurer un portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
         <source>Enter your 25 word mnemonic seed:</source>
-        <translation>Entrez votre graine mnémonique de 25 mots :</translation>
+        <translation type="vanished">Entrez votre graine mnémonique de 25 mots :</translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Bienvenue</translation>
+        <translation type="vanished">Bienvenue</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Bienvenue dans Monero !</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Veuillez choisir une langue et un format régional.</translation>
     </message>
@@ -1959,19 +2123,19 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Impossible d&apos;ouvrir le portefeuille : </translation>
     </message>
@@ -1980,75 +2144,90 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Synchronisation des blocs %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Solde débloqué (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation>Attente du démarrage du démon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Attente de l&apos;arrêt du démon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Impossible de créer la transaction : mauvaise version de démon : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Impossible de créer la transaction : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Aucune sortie non mélangeable à balayer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Veuillez confirmer la transaction :
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Adresse : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
 ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -2057,24 +2236,50 @@ Amount: </source>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished">Arrêter démon</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>
 
 Ring size: </source>
-        <translation>
+        <translation type="vanished">
 
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Cette adresse a reçu %1 monero, avec %2 confirmation(s).</translation>
     </message>
@@ -2087,14 +2292,14 @@ Mixin: </source>
 Mixin : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -2103,42 +2308,42 @@ Description: </source>
 Description : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Montant erroné : nombre entre %1 et %2 attendu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>fonds insuffisants. Solde débloqué : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Impossible d&apos;envoyer l&apos;argent : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Argent envoyé avec succès : %1 transaction(s) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transaction enregistrée dans le fichier : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Vérification de paiement</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Cette adresse a reçu %1 monero, mais la transaction n&apos;a pas encore été incluse dans un bloc</translation>
     </message>
@@ -2147,37 +2352,37 @@ Description : </translation>
         <translation type="vanished">Cette adresse a reçu %1 monero, avec %2 confirmations</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Cette adresse n&apos;a rien reçu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation>Solde (synchronisation en cours)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Veuillez patienter…</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Assistant de configuration du programme</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>envoyer à la même destination</translation>
     </message>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -928,7 +928,7 @@
         <translation type="vanished">Les portefeuilles en vue seule n&apos;ont pas de graine mnémonique</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation>Créer portefeuille vue seule</translation>
     </message>
@@ -937,22 +937,22 @@
         <translation type="vanished">Il est très important de l&apos;écrire sur papier et de le garder secret. C&apos;est tout ce dont vous aurez besoin pour restaurer votre portefeuille.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Montrer la graine</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation>Gérer le démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation>Lancer démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation>Arrêter démon</translation>
     </message>
@@ -965,107 +965,107 @@
         <translation type="vanished">Statut</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation>Options de démarrage</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Adresse du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Nom d&apos;hôte / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Mot de passe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation>Réglages d&apos;agencement</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation>Décorations personnalisées</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation>Niveau journal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation>Version de l&apos;interface graphique : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation>Version de Monero incorporée : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation>Journal du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation>Mauvais mot de passe</translation>
     </message>
@@ -1079,7 +1079,7 @@
         <translation type="vanished">Fermer le portefeuille courant et ouvrir l&apos;assistant</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Fermer</translation>
     </message>
@@ -1369,112 +1369,112 @@
         <translation>Enregistré dans l&apos;historique du portefeuille local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Envoyer</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation>créer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation>signer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation>Soumettre fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation>Scan dépenses</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation>Les sorties dépensées ont été rescannées avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Impossible de charger une transaction non signée : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transaction #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation>
 Destinataire : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation>
 identifiant de paiement : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
@@ -1486,35 +1486,35 @@ Ring size: </source>
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Impossible de soumettre la transaction : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation>Argent envoyé avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Le portefeuille n&apos;est pas connecté au démon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Le démon connecté n&apos;est pas compatible avec l&apos;interface graphique. 
 Veuillez mettre à jour ou vous connecter à un autre démon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Attente de la fin de la synchronisation avec le démon</translation>
     </message>
@@ -1544,7 +1544,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Niveau de confidentialité</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Coût de transaction</translation>
     </message>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -928,7 +928,7 @@
         <translation type="vanished">Les portefeuilles en vue seule n&apos;ont pas de graine mnémonique</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation>Créer portefeuille vue seule</translation>
     </message>
@@ -937,22 +937,22 @@
         <translation type="vanished">Il est très important de l&apos;écrire sur papier et de le garder secret. C&apos;est tout ce dont vous aurez besoin pour restaurer votre portefeuille.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Montrer la graine</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Gérer le démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Lancer démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Arrêter démon</translation>
     </message>
@@ -965,107 +965,107 @@
         <translation type="vanished">Statut</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation>Options de démarrage</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Adresse du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nom d&apos;hôte / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Mot de passe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation>Réglages d&apos;agencement</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation>Décorations personnalisées</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation>Niveau journal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation>Version de l&apos;interface graphique : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation>Version de Monero incorporée : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Journal du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Mauvais mot de passe</translation>
     </message>
@@ -1079,7 +1079,7 @@
         <translation type="vanished">Fermer le portefeuille courant et ouvrir l&apos;assistant</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Fermer</translation>
     </message>
@@ -1129,6 +1129,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1138,6 +1143,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1293,6 +1303,11 @@
         <translation type="vanished">RÉSOUDRE</translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="78"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
@@ -1369,112 +1384,118 @@
         <translation>Enregistré dans l&apos;historique du portefeuille local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Envoyer</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation>créer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation>signer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation>Soumettre fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation>Scan dépenses</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation>Les sorties dépensées ont été rescannées avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Impossible de charger une transaction non signée : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transaction #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation>
 Destinataire : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation>
 identifiant de paiement : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
@@ -1486,35 +1507,35 @@ Ring size: </source>
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Impossible de soumettre la transaction : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation>Argent envoyé avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Le portefeuille n&apos;est pas connecté au démon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Le démon connecté n&apos;est pas compatible avec l&apos;interface graphique. 
 Veuillez mettre à jour ou vous connecter à un autre démon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Attente de la fin de la synchronisation avec le démon</translation>
     </message>
@@ -1544,7 +1565,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation type="vanished">Niveau de confidentialité</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Coût de transaction</translation>
     </message>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -49,6 +49,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -71,11 +76,6 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="138"/>
         <source>Give this entry a name or description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
-        <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -131,28 +131,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -241,7 +231,7 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
-        <source>FILTER</source>
+        <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -455,105 +445,115 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
-        <source>Unlocked Balance:</source>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -561,27 +561,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
-        <source>Connected</source>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="54"/>
-        <source>Wrong version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
-        <source>Disconnected</source>
+        <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <source>Wrong version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -599,12 +604,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,30 +617,35 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
-        <source>LOW</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
-        <source>MEDIUM</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
-        <source>HIGH</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -703,6 +713,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
@@ -745,11 +760,6 @@
     <message>
         <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -803,144 +813,142 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>Click button to show seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -986,19 +994,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1025,12 +1039,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1044,12 +1052,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1058,232 +1066,207 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,33 +1276,58 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
-        <source>SEND</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1376,13 +1384,13 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
-        <source>Transaction key</source>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
+        <location filename="../pages/TxKey.qml" line="181"/>
+        <source>Transaction key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1427,7 +1435,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1437,11 +1445,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1481,57 +1484,62 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1543,43 +1551,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1587,47 +1595,47 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1648,27 +1656,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1686,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1686,13 +1694,13 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1701,7 +1709,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1714,25 +1722,20 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
-        <source>Welcome</source>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,199 +1743,234 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -998,6 +998,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1036,6 +1041,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1134,139 +1144,145 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,13 +1292,18 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -813,132 +813,132 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -948,7 +948,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,139 +1134,139 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1276,7 +1276,7 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -900,132 +900,132 @@
         <translation type="vanished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Menunjukkan biji acak</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Alamat jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nama host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Kata sandi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Menyimpan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1039,7 @@
         <translation type="vanished">Menutup dompet saat ini dan membuka wizard</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Menutup dompet</translation>
     </message>
@@ -1089,6 +1089,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1098,6 +1103,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1212,6 +1222,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
@@ -1293,139 +1308,145 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">KIRIM</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1455,7 +1476,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Tingkatan privasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Biaya transaksi</translation>
     </message>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -900,132 +900,132 @@
         <translation type="vanished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Menunjukkan biji acak</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Alamat jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Nama host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Kata sandi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Menyimpan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1039,7 @@
         <translation type="vanished">Menutup dompet saat ini dan membuka wizard</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Menutup dompet</translation>
     </message>
@@ -1293,139 +1293,139 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">KIRIM</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Informasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1455,7 +1455,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">Tingkatan privasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Biaya transaksi</translation>
     </message>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -4,55 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>Membuat alamat baru</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Menandai Pembayaran&lt;font size=&apos;2&apos;&gt;(Ikhtiari)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;Menandai Pembayaran&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Pengenal unik degunakan dalam&lt;br/&gt;buku alamal. Tidak pernah dikirim ke orang-orang lain</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
-        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>Catatan &lt;font size=&apos;2&apos;&gt;(Disimpan secara lokal)&lt;/font&gt;</translation>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
+        <translation type="vanished">Catatan &lt;font size=&apos;2&apos;&gt;(Disimpan secara lokal)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>TAMBAH</translation>
+        <translation type="vanished">TAMBAH</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>Menandai Pembayaran</translation>
+        <translation type="vanished">Menandai Pembayaran</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>Catatan</translation>
+        <translation type="vanished">Catatan</translation>
     </message>
 </context>
 <context>
@@ -92,16 +132,45 @@
     </message>
 </context>
 <context>
-    <name>DaemonProgress</name>
+    <name>DaemonConsole</name>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation>Menerima dan memeriksa blok %1/%2</translation>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="87"/>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonManagerDialog</name>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonProgress</name>
+    <message>
+        <source>Synchronizing blocks %1/%2</source>
+        <translation type="vanished">Menerima dan memeriksa blok %1/%2</translation>
+    </message>
+    <message>
         <source>Synchronizing blocks</source>
-        <translation>Menerima dan memeriksa blok</translation>
+        <translation type="vanished">Menerima dan memeriksa blok</translation>
     </message>
 </context>
 <context>
@@ -163,57 +232,63 @@
         <translation>&lt;b&gt;Jumlah total untuk pembayaran yang dipilih&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="181"/>
+        <location filename="../pages/History.qml" line="182"/>
+        <source>Type for incremental search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
-        <translation>Pencarian aktif</translation>
+        <translation type="vanished">Pencarian aktif</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
         <source>Search transfers for a given string</source>
-        <translation>Cari pembayaran dengan catatan khusus</translation>
+        <translation type="vanished">Cari pembayaran dengan catatan khusus</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="194"/>
         <source>Type search string</source>
-        <translation>Masukan catatan yang ingin dicari</translation>
+        <translation type="vanished">Masukan catatan yang ingin dicari</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="234"/>
+        <location filename="../pages/History.qml" line="222"/>
         <source>Date from</source>
         <translation>Dari tanggal</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="236"/>
-        <location filename="../pages/History.qml" line="261"/>
-        <location filename="../pages/History.qml" line="343"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="224"/>
+        <location filename="../pages/History.qml" line="249"/>
+        <location filename="../pages/History.qml" line="331"/>
+        <location filename="../pages/History.qml" line="366"/>
+        <location filename="../pages/History.qml" line="398"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="259"/>
-        <location filename="../pages/History.qml" line="408"/>
+        <location filename="../pages/History.qml" line="247"/>
+        <location filename="../pages/History.qml" line="396"/>
         <source>To</source>
         <translation>Ke</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="285"/>
         <source>FILTER</source>
-        <translation>MENYARING</translation>
+        <translation type="vanished">MENYARING</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="322"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Advanced filtering</source>
         <translation>Penyaringan terperinci</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="341"/>
+        <location filename="../pages/History.qml" line="329"/>
         <source>Type of transaction</source>
         <translation>Golongan transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="364"/>
         <source>Amount from</source>
         <translation>Jumlah dari</translation>
     </message>
@@ -221,53 +296,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation>Menandai transaksi:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>Menandai pembayaran:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation>Kunci transaksi:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation>Catatan untuk transaksi:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="66"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>Hasil selesai</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="97"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>Perincian</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>Ketinggian blok:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>Biaya</translation>
     </message>
@@ -275,78 +370,120 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>Saldo Rekening</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>Saldo rekening yang tidak terkunci</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>KIRIM</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
         <source>T</source>
-        <translation>T</translation>
+        <translation type="vanished">T</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>Menerima</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>Mengesahkan pembayaran</translation>
+        <translation type="vanished">Mengesahkan pembayaran</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>Daftar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
         <source>Sign/verify</source>
         <translation>Menandatangani/mengesahkan</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="395"/>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
@@ -354,40 +491,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="193"/>
         <source>Balance:</source>
-        <translation>Saldo rekening:</translation>
+        <translation type="vanished">Saldo rekening:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="231"/>
         <source>Unlocked Balance:</source>
-        <translation>Saldo rekening yang tidak terkunci:</translation>
+        <translation type="vanished">Saldo rekening yang tidak terkunci:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo Rekening</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Tersambung</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Versi salah</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Koneksi terputus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Status sambungan salah</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Status jaringan</translation>
     </message>
@@ -395,17 +653,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="68"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>Silahkan masuk kata sandi untuk dompet anda</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="143"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
+        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Membatalkan</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="158"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -413,66 +676,175 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>RENDAH</translation>
+        <translation type="vanished">RENDAH</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>SEDANG</translation>
+        <translation type="vanished">SEDANG</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>TINGGI</translation>
+        <translation type="vanished">TINGGI</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProgressBar</name>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
+        <source>Synchronizing blocks</source>
+        <translation type="unfinished">Menerima dan memeriksa blok</translation>
     </message>
 </context>
 <context>
     <name>Receive</name>
     <message>
-        <location filename="../pages/Receive.qml" line="56"/>
+        <location filename="../pages/Receive.qml" line="63"/>
         <source>Invalid payment ID</source>
         <translation>Menandai pembayaran salah</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="100"/>
+        <source>WARNING: no connection to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="122"/>
+        <source>in the txpool: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="129"/>
+        <source>%2 confirmations: %3 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="131"/>
+        <source>1 confirmation: %2 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="139"/>
+        <source>No transaction found yet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>Transaction found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>%1 transactions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="149"/>
+        <source> with more money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="151"/>
+        <source> with not enough money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="182"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="189"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Alamat dompet BacaSaja ditampilkan disini</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Alamat tergabung (menandai pembayaran sudah termasuk)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>Alamat tergabung dompet BacaSaja ditampilkan disini</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="162"/>
+        <location filename="../pages/Receive.qml" line="320"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="325"/>
+        <source>Tracking payments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="326"/>
+        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>Menandai pembayaran</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="170"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 atau 64 simbol heksadesimal</translation>
+        <translation type="vanished">16 atau 64 simbol heksadesimal</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="195"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>Membuat</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="209"/>
-        <location filename="../pages/Receive.qml" line="217"/>
+        <location filename="../pages/Receive.qml" line="291"/>
+        <location filename="../pages/Receive.qml" line="299"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
@@ -516,58 +888,158 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="51"/>
-        <location filename="../pages/Settings.qml" line="110"/>
         <source>Click button to show seed</source>
-        <translation>Pekan tombol untuk menunjukkan biji acak Anda</translation>
+        <translation type="vanished">Pekan tombol untuk menunjukkan biji acak Anda</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
         <source>Mnemonic seed: </source>
-        <translation>Kata-kata biji acak Anda:</translation>
+        <translation type="vanished">Kata-kata biji acak Anda:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="139"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
+        <translation type="vanished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="152"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Menunjukkan biji acak</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="182"/>
+        <location filename="../pages/Settings.qml" line="133"/>
+        <source>Manage daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="150"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="164"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Alamat jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Nama host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="200"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="212"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Kata sandi</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Menyimpan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="238"/>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="403"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
+        <source>Error</source>
+        <translation type="unfinished">Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="423"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Mengelola dompet Anda</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="251"/>
         <source>Close current wallet and open wizard</source>
-        <translation>Menutup dompet saat ini dan membuka wizard</translation>
+        <translation type="vanished">Menutup dompet saat ini dan membuka wizard</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="262"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Menutup dompet</translation>
     </message>
@@ -613,8 +1085,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>MENANDATANGANI</translation>
+        <translation type="vanished">MENANDATANGANI</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -623,10 +1116,8 @@
         <translation>Atau arsip:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>MEMILIH</translation>
+        <translation type="vanished">MEMILIH</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -652,10 +1143,8 @@
         <translation>Pesan untuk disahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>MENGESAHKAN</translation>
+        <translation type="vanished">MENGESAHKAN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -663,20 +1152,19 @@
         <translation>Nama arsip dengan pesan untuk disahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Alamat penandatanganan &lt;font size=&apos;2&apos;&gt;  ( Mengetikkan atau memilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Alamat penandatanganan &lt;font size=&apos;2&apos;&gt;  ( Mengetikkan atau memilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="105"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="121"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Membatalkan</translation>
     </message>
@@ -684,32 +1172,262 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>RENDAH</translation>
+        <translation type="vanished">RENDAH</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">SEDANG</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">TINGGI</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>SEDANG</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>TINGGI</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="59"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="69"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Kepentingan transaksi</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">KIRIM</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">Informasi</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Konfirmasi</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
+        <source>Wallet is not connected to daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="720"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="725"/>
+        <source>Waiting on daemon synchronization to finish</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="91"/>
@@ -717,92 +1435,103 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="108"/>
         <source>or ALL</source>
-        <translation>atau SEMUA</translation>
+        <translation type="vanished">atau SEMUA</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="124"/>
         <source>LOW</source>
-        <translation>RENDAH</translation>
+        <translation type="vanished">RENDAH</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
         <source>MEDIUM</source>
-        <translation>SEDANG</translation>
+        <translation type="vanished">SEDANG</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
         <source>HIGH</source>
-        <translation>TINGGI</translation>
+        <translation type="vanished">TINGGI</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="155"/>
         <source>Privacy level</source>
-        <translation>Tingkatan privasi</translation>
+        <translation type="vanished">Tingkatan privasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="181"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Biaya transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Alamat &lt;font size=&apos;2&apos;&gt;  ( Mengetikkan atau memilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Alamat &lt;font size=&apos;2&apos;&gt;  ( Mengetikkan atau memilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="223"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Menandai pembayaran &lt;font size=&apos;2&apos;&gt;( Ikhtiari )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="235"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 atau 64 simbol heksadesimal</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="248"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( An optional description that will be saved to the local address book if entered )&lt;/font&gt;</source>
-        <translation>Catatan &lt;font size=&apos;2&apos;&gt;(Catatan ikhtiari yang akan disimpan dalam buku alamat lokal)&lt;/font&gt;</translation>
+        <translation type="vanished">Catatan &lt;font size=&apos;2&apos;&gt;(Catatan ikhtiari yang akan disimpan dalam buku alamat lokal)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="296"/>
         <source>SEND</source>
-        <translation>KIRIM</translation>
+        <translation type="vanished">KIRIM</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation>MENGUMPULKAN KELUARAN YANG TIDAK DAPAT DICAMPUR</translation>
+        <translation type="vanished">MENGUMPULKAN KELUARAN YANG TIDAK DAPAT DICAMPUR</translation>
     </message>
 </context>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
         <source>You can verify that a third party made a payment by supplying:</source>
-        <translation>Anda bisa periksa pembayaran oleh pihak ketiga dengan:</translation>
+        <translation type="vanished">Anda bisa periksa pembayaran oleh pihak ketiga dengan:</translation>
+    </message>
+    <message>
+        <source> - the recipient address,</source>
+        <translation type="vanished"> - alamat penerima,</translation>
+    </message>
+    <message>
+        <source> - the transaction ID,</source>
+        <translation type="vanished"> - menandai transaksi</translation>
+    </message>
+    <message>
+        <source> - the tx secret key supplied by the sender</source>
+        <translation type="vanished"> - rahasia transaksi dari pengirim</translation>
+    </message>
+    <message>
+        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
+        <translation type="vanished">Jika pembayaran termasuk beberapa transaksi, setiapnya harus diperiksa dan hasil ditambah</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="90"/>
+        <source>Verify that a third party made a payment by supplying:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="94"/>
-        <source> - the recipient address,</source>
-        <translation> - alamat penerima,</translation>
+        <source> - the recipient address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="98"/>
-        <source> - the transaction ID,</source>
-        <translation> - menandai transaksi</translation>
+        <source> - the transaction ID</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="102"/>
-        <source> - the tx secret key supplied by the sender</source>
-        <translation> - rahasia transaksi dari pengirim</translation>
+        <source> - the secret transaction key supplied by the sender</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
-        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
-        <translation>Jika pembayaran termasuk beberapa transaksi, setiapnya harus diperiksa dan hasil ditambah</translation>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -821,8 +1550,22 @@
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="157"/>
+        <source>Paste tx ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="189"/>
+        <source>Paste tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transaction ID here</source>
-        <translation>Menandai transaksi disini</translation>
+        <translation type="vanished">Menandai transaksi disini</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="181"/>
@@ -830,14 +1573,12 @@
         <translation>Kunci transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="189"/>
         <source>Transaction key here</source>
-        <translation>Kunci transaksi disini</translation>
+        <translation type="vanished">Kunci transaksi disini</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="213"/>
         <source>CHECK</source>
-        <translation>MEMERIKSA</translation>
+        <translation type="vanished">MEMERIKSA</translation>
     </message>
 </context>
 <context>
@@ -853,42 +1594,57 @@
         <translation>Mulailah rantaiblok Monero?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="115"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan. Langsung, Anda akan diminta memastikan biji acak supaya dicatat dengan benar</translation>
+        <translation type="vanished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan. Langsung, Anda akan diminta memastikan biji acak supaya dicatat dengan benar</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="127"/>
+        <location filename="../wizard/WizardConfigure.qml" line="115"/>
+        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
+        <translation type="unfinished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardConfigure.qml" line="126"/>
         <source>Enable disk conservation mode?</source>
         <translation>Menggunakan disk cara penghematan?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="145"/>
+        <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
         <translation>Cara penghematan bisa mengurangi ruang hard disk untuk Monero, tetapi tidak mengurangi jumlah data. Menyimpan rantaiblok lengkap bermanfaat untuk jaringan. Kalau Anda punya hard disk yang kecil, pilihan ini sesuai untuk Anda.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="158"/>
+        <location filename="../wizard/WizardConfigure.qml" line="157"/>
         <source>Allow background mining?</source>
         <translation>Mengizinkan pertambangan di balik layar?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="176"/>
+        <location filename="../wizard/WizardConfigure.qml" line="175"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>Pertambangan menjaminkan sekuritas jaringan Monero, dan juga mengeluarkan hadiah kecil kepada yang menambang dengan sukses. Pilihan ini mengizinkan Monero untuk pertambangan kapan komputer Anda menggunakan daya listrik dan Anda tidak bekerja. Pertambangan berhenti sewaktu saat Anda bekerja lagi.</translation>
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="94"/>
         <source>A new wallet has been created for you</source>
-        <translation>Dompet baru telah dibuat untuk Anda</translation>
+        <translation type="vanished">Dompet baru telah dibuat untuk Anda</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="95"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>Ini adalah 25 kata biji acak untuk dompet Anda</translation>
+        <translation type="vanished">Ini adalah 25 kata biji acak untuk dompet Anda</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -927,97 +1683,182 @@
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Diaktifkan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Dinonaktifkan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>Nama saldo rekening</translation>
+        <translation type="vanished">Nama saldo rekening</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>Biji acak</translation>
+        <translation type="vanished">Biji acak</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Path untuk dompet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Alamat jurik</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet (jaringan pelatihan)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Mengembalikan dompet dari blok nomor</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
-        <source>An overview of your Monero configuration is below:</source>
-        <translation>Gambaran ikhtisar konfigurasi Monero Anda diberikan di bawah ini:</translation>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
+        <source>You’re all set up!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An overview of your Monero configuration is below:</source>
+        <translation type="vanished">Gambaran ikhtisar konfigurasi Monero Anda diberikan di bawah ini:</translation>
+    </message>
+    <message>
         <source>You’re all setup!</source>
-        <translation>Semua sudah selesai!</translation>
+        <translation type="vanished">Semua sudah selesai!</translation>
     </message>
 </context>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="202"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Dompet bernama ini sudah ada. Tolong mengganti nama dompet yang baru</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="337"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <source>Non-ASCII characters are not allowed in wallet path or account name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>MENGGUNAKAN MONERO</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>Ini nama dompet Anda. Bisa digantikan untuk nama lain kalau Anda mau:</translation>
+        <translation type="vanished">Ini nama dompet Anda. Bisa digantikan untuk nama lain kalau Anda mau:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>Mengembalikan dompet dari blok nomor</translation>
+        <translation type="vanished">Mengembalikan dompet dari blok nomor</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Dompet Anda disimpan di</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Silahkan memilihkan direktori</translation>
     </message>
@@ -1025,45 +1866,70 @@
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan. Langsung, Anda akan diminta memastikan biji acak supaya dicatat dengan benar</translation>
+        <translation type="vanished">Sangat penting ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan. Langsung, Anda akan diminta memastikan biji acak supaya dicatat dengan benar</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Selamat datang di dunia Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Mohon memilihkan salah satu opsi:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>Ini saat pertama saya, dan saya ingin membuat rekening yang baru</translation>
+        <translation type="vanished">Ini saat pertama saya, dan saya ingin membuat rekening yang baru</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>Saya ingin mengembalikan rekening dari 25 kata-kata biji acak saya</translation>
+        <translation type="vanished">Saya ingin mengembalikan rekening dari 25 kata-kata biji acak saya</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>Saya ingin membuka dompet dari arsip</translation>
+        <translation type="vanished">Saya ingin membuka dompet dari arsip</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>Mohon mendirikan alamat jurik di bawah</translation>
+        <translation type="vanished">Mohon mendirikan alamat jurik di bawah</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet (jaringan pelatihan)</translation>
     </message>
@@ -1071,55 +1937,82 @@
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>Mohon memilih kata sandi untuk dompet anda yang baru dibuat</translation>
+        <translation type="vanished">Mohon memilih kata sandi untuk dompet anda yang baru dibuat</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>Mohon memilih kata sandi untuk dompet anda yang baru dikembalikan</translation>
+        <translation type="vanished">Mohon memilih kata sandi untuk dompet anda yang baru dikembalikan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="138"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>Ingatlah kata sandi ini tidak dapat dikembalikan, dan kalau lupa, dompet Anda harus dikembalikan dari biji acak yang baru dicatat&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">Ingatlah kata sandi ini tidak dapat dikembalikan, dan kalau lupa, dompet Anda harus dikembalikan dari biji acak yang baru dicatat&lt;br/&gt;&lt;br/&gt;
                         Kata sandi anda akan digunakan supaya melindungi dompet Anda dan juga mengizinkan setiap tindakan, jadi memastikan kata sandi Anda cukup sulit</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="152"/>
         <source>Password</source>
-        <translation>Kata sandi</translation>
+        <translation type="vanished">Kata sandi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="165"/>
         <source>Confirm password</source>
-        <translation>Memastikan kata sandi</translation>
+        <translation type="vanished">Memastikan kata sandi</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">Kata sandi</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Memastikan kata sandi</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="87"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>Siap mengembalikan rekening Anda</translation>
+        <translation type="vanished">Siap mengembalikan rekening Anda</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="88"/>
         <source>Please enter your 25 word private key</source>
-        <translation>Silahkan memasuk 25 kata biji acak Anda</translation>
+        <translation type="vanished">Silahkan memasuk 25 kata biji acak Anda</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Selamat Datang</translation>
+        <translation type="vanished">Selamat Datang</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Selamat datang di dunia Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Silahkan memilih bahasa dan pilihan daerah</translation>
     </message>
@@ -1127,157 +2020,273 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="248"/>
-        <location filename="../main.qml" line="369"/>
-        <location filename="../main.qml" line="430"/>
-        <location filename="../main.qml" line="441"/>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="546"/>
-        <location filename="../main.qml" line="575"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="249"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Tidak bisa membuka dompet: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="336"/>
         <source>Synchronizing blocks %1 / %2</source>
-        <translation>Menerima dan memeriksa blok %1 / %2</translation>
+        <translation type="vanished">Menerima dan memeriksa blok %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="371"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Tidak bisa membuat transaksi: Versi jurik yang salah: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="373"/>
-        <location filename="../main.qml" line="466"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Tidak bisa membuat transaksi: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="381"/>
-        <location filename="../main.qml" line="382"/>
-        <location filename="../main.qml" line="474"/>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Tidak ada keluaran yang tidak dapat dicampur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
-        <location filename="../main.qml" line="487"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="395"/>
-        <location filename="../main.qml" line="488"/>
         <source>Please confirm transaction:</source>
-        <translation>Silahkan mengkonfirmasi transaksi:</translation>
+        <translation type="vanished">Silahkan mengkonfirmasi transaksi:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="396"/>
         <source>Address: </source>
-        <translation>Alamat: </translation>
+        <translation type="vanished">Alamat: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="397"/>
         <source>Payment ID: </source>
-        <translation>Menandai pembayaran : </translation>
+        <translation type="vanished">Menandai pembayaran : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="398"/>
-        <location filename="../main.qml" line="489"/>
         <source>Amount: </source>
-        <translation>Jumlah: </translation>
+        <translation type="vanished">Jumlah: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="490"/>
         <source>Fee: </source>
-        <translation>Biaya: </translation>
+        <translation type="vanished">Biaya: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
         <source>Mixin: </source>
-        <translation>Campuran: </translation>
+        <translation type="vanished">Campuran: </translation>
+    </message>
+    <message>
+        <source>Number of transactions: </source>
+        <translation type="vanished">Nomor transaksi: </translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="vanished">Catatan: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">Saldo rekening yang tidak terkunci</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
+        <source>Waiting for daemon to start...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="401"/>
-        <source>Number of transactions: </source>
-        <translation>Nomor transaksi: </translation>
+        <source>Waiting for daemon to stop...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
-        <source>Description: </source>
-        <translation>Catatan: </translation>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="431"/>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
+        <source>Please confirm transaction:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="503"/>
+        <source>
+Address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="504"/>
+        <source>
+Payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
+        <source>
+
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="509"/>
+        <source>
+
+Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Jumlah salah: nomor antar %1 dan %2 diharapkan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>Dana tidak mencukupi. Saldo rekening yang tidak terkunci: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Tidak bisa mengirim uang monero: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informasi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Uang monero dikirim dengan sukses: %1 transaksi </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Mengesahkan pembayaran</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Alamat ini menerima %1 monero, tetapi transaksinya belum termasuk dalam blok</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
-        <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>Alamat ini menerima %1 monero, dengan  %2 konfirmasi</translation>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="571"/>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This address received %1 monero, with %2 confirmations</source>
+        <translation type="vanished">Alamat ini menerima %1 monero, dengan  %2 konfirmasi</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Alamat ini tidak menerima apa-apa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="731"/>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo Rekening</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Mohon tunggu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="756"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Wizard untuk medirikan program ini</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="770"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>kirim ke tujuan yang sama</translation>
     </message>

--- a/translations/monero-core_in.ts
+++ b/translations/monero-core_in.ts
@@ -906,137 +906,137 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1086,6 +1086,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1124,6 +1129,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1210,7 +1220,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1261,6 +1271,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="175"/>
         <source>all</source>
         <translation type="unfinished"></translation>
@@ -1296,139 +1311,145 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">जानकारी</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">पैसे सफलतापूर्वक भेजे गए</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_in.ts
+++ b/translations/monero-core_in.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
@@ -78,9 +83,8 @@
         <translation type="vanished">विवरण &lt;font size=&apos;2&apos;&gt;(स्थानीय डेटाबेस)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>जोड़ें</translation>
+        <translation type="vanished">जोड़ें</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -163,28 +167,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -289,8 +283,12 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>FILTER</source>
-        <translation>फिल्टर करें</translation>
+        <translation type="vanished">फिल्टर करें</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -519,105 +517,115 @@
         <translation type="unfinished">धनराशि</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
-        <source>Unlocked Balance:</source>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -625,27 +633,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>नेटवर्क स्थिति</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>कनेक्ट किया गया</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>डिस्कनेक्ट किया गया</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -663,12 +676,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -676,30 +689,47 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>निम्न</translation>
+        <translation type="vanished">निम्न</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>मध्यम</translation>
+        <translation type="vanished">मध्यम</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>उच्च</translation>
+        <translation type="vanished">उच्च</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,7 +798,7 @@
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
+        <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -871,144 +901,142 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>Click button to show seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1054,19 +1082,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1093,12 +1127,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1112,12 +1140,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1129,19 +1157,27 @@
         <translation type="vanished">निम्न</translation>
     </message>
     <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">मध्यम</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">उच्च</translation>
+    </message>
+    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>मध्यम</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>उच्च</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1154,22 +1190,17 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>लेनदेन प्राथमिकता</translation>
     </message>
@@ -1179,215 +1210,225 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">जानकारी</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">पैसे सफलतापूर्वक भेजे गए</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1420,7 +1461,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="obsolete">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    पता &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;पता&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; पुस्तिका  )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>भुगतान आईडी &lt;font size=&apos;2&apos;&gt;( वैकल्पिक )&lt;/font&gt;</translation>
     </message>
@@ -1429,9 +1470,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">विवरण &lt;font size=&apos;2&apos;&gt;( एक वैकल्पिक विवरण जिसे दर्ज़ करने पर यह स्थानीय पता पुस्तिका में सहेजा जायेगा )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>भेजें</translation>
+        <translation type="vanished">भेजें</translation>
     </message>
 </context>
 <context>
@@ -1493,7 +1533,7 @@ Please upgrade or connect to another daemon</source>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
+        <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1542,7 +1582,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1560,11 +1600,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1640,57 +1675,62 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">आप बिल्कुल तैयार हैं!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1702,43 +1742,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>MONERO प्रयोग करें</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1754,47 +1794,47 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">मेरा खाता नाम</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>आपका वॉलेट संग्रहीत है</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>कृपया निर्देशिका चुनें</translation>
     </message>
@@ -1819,27 +1859,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Monero में आपका स्वागत है!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>कृपया निम्नलिखित विकल्पों में से एक का चयन करें:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1849,7 +1889,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1879,13 +1919,13 @@ Please upgrade or connect to another daemon</source>
                         आपका पासवर्ड वॉलेट सुरक्षित रखने के लिए और गतिविधियों की पुष्टि करने के लिए प्रयोग किया जायेगा, तो इस बात का ध्यान रखें कि आपका पासवर्ड पर्याप्त रूप से सुरक्षित रहे।</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1894,7 +1934,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1919,25 +1959,24 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">कृपया अपनी 25 शब्दों की गोपनीय कुंजी डालें</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>आपका स्वागत है</translation>
+        <translation type="vanished">आपका स्वागत है</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Monero में आपका स्वागत है!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>कृपया अपनी भाषा और क्षेत्रीय स्वरूप डालें।</translation>
     </message>
@@ -1945,178 +1984,213 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>त्रुटि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>वॉलेट नहीं खुल पाया: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">खुली धनराशि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>लेनदेन नहीं हो सकता है: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
+        <location filename="../main.qml" line="507"/>
         <source>
 
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">धनराशि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2141,12 +2215,12 @@ Description: </source>
         <translation type="vanished">शुल्क:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>पैसेनहीं भेज पाया: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>जानकारी</translation>
     </message>
@@ -2159,7 +2233,7 @@ Description: </source>
         <translation type="vanished">वॉलेट प्रारंभ हो रहा है...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>प्रोग्राम सेटअप विज़ार्ड</translation>
     </message>
@@ -2168,7 +2242,7 @@ Description: </source>
         <translation type="vanished">Monero  -  डोनेशन</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>समान गंतव्य पर भेजें</translation>
     </message>

--- a/translations/monero-core_in.ts
+++ b/translations/monero-core_in.ts
@@ -906,137 +906,137 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,7 +1210,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1296,139 +1296,139 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">जानकारी</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">पैसे सफलतापूर्वक भेजे गए</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
@@ -82,9 +87,8 @@
         <translation type="vanished">Descrizione &lt;font size=&apos;2&apos;&gt;(Database locale)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>AGGIUNGI</translation>
+        <translation type="vanished">AGGIUNGI</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -147,28 +151,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -276,8 +270,12 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>FILTER</source>
-        <translation>FILTRA</translation>
+        <translation type="vanished">FILTRA</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -506,105 +504,119 @@
         <translation type="unfinished">Totale</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unlocked Balance:</source>
-        <translation>Totale Sbloccato:</translation>
+        <translation type="vanished">Totale Sbloccato:</translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,27 +624,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Stato Rete</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Connesso</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -650,12 +667,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -663,30 +680,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>BASSA</translation>
+        <translation type="vanished">BASSA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>MEDIA</translation>
+        <translation type="vanished">MEDIA</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>ALTA</translation>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation type="unfinished">Sincronizzazione blocchi %1/%2</translation>
+        <translation type="obsolete">Sincronizzazione blocchi %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished">Sincronizzazione blocchi</translation>
     </message>
@@ -754,6 +792,11 @@
         <translation>Portafoglio in sola lettura</translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Indirizzo integrato</translation>
@@ -782,11 +825,6 @@
         <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>ID Pagamento</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -858,24 +896,16 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>Click button to show seed</source>
-        <translation>Clicca il bottone per mostrare il seed</translation>
+        <translation type="vanished">Clicca il bottone per mostrare il seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -888,108 +918,118 @@
         <translation type="vanished">E&apos; veramente importante che ti salvi queste parole in quanto sono l&apos;unico backup che serve per il tuo portafoglio.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Mostra seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Password</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -997,17 +1037,17 @@
         <translation type="vanished">Indirizzo processo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
@@ -1053,19 +1093,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1092,12 +1138,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1111,12 +1151,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1128,30 +1168,38 @@
         <translation type="vanished">BASSA</translation>
     </message>
     <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">MEDIA</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">ALTA</translation>
+    </message>
+    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>MEDIA</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>ALTA</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Quantità</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Priorità Transazione</translation>
     </message>
@@ -1185,220 +1233,235 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID Pagamento &lt;font size=&apos;2&apos;&gt;( Opzionale )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informazioni</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">Totale: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">Commissione: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Conferma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">Denaro inviato correttamente</translation>
     </message>
@@ -1407,19 +1470,8 @@ Ring size: </source>
         <translation type="vanished">descrizione &lt;font size=&apos;2&apos;&gt;( Una descrizione opzionale che sarà salvata nella tua rubrica )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>INVIA</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">INVIA</translation>
     </message>
 </context>
 <context>
@@ -1470,6 +1522,11 @@ Ring size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation type="unfinished"></translation>
@@ -1477,11 +1534,6 @@ Ring size: </source>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1530,7 +1582,7 @@ Ring size: </source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,11 +1600,6 @@ Ring size: </source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1632,57 +1679,62 @@ Ring size: </source>
         <translation type="vanished">&lt;b&gt;Ripristino: &lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished">Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished">Ripristino</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1702,43 +1754,43 @@ Ring size: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>USA MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1758,47 +1810,47 @@ Ring size: </source>
         <translation type="vanished">Ripristino</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Il tuo portafoglio è salvato in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Seleziona una cartella</translation>
     </message>
@@ -1827,27 +1879,27 @@ Ring size: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Benvenuto in Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Seleziona una delle seguenti opzioni:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1873,7 +1925,7 @@ Ring size: </source>
         <translation type="vanished">Imposta l&apos;indirizzo del processo qui sotto.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1903,13 +1955,13 @@ Ring size: </source>
         <translation type="vanished">Conferma Password</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1918,7 +1970,7 @@ Ring size: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished">Password</translation>
     </message>
@@ -1943,25 +1995,24 @@ Ring size: </source>
         <translation type="vanished">Inserisci le tue 25 parole private</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Benvenuto</translation>
+        <translation type="vanished">Benvenuto</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Benvenuto in Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Seleziona una lingua e un formato regionale.</translation>
     </message>
@@ -1969,14 +2020,14 @@ Ring size: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
@@ -1985,91 +2036,133 @@ Ring size: </source>
         <translation type="vanished">Sincronizzazione blocchi %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>La quantità è sbagliata: à previsto un numero tra l&apos;%1 e il %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Impossibile creare la transazione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">Totale sbloccato</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2079,13 +2172,13 @@ Description: </source>
         <translation type="vanished">Conferma la transazione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>ID Pagamento: </translation>
@@ -2096,31 +2189,24 @@ Amount: </source>
         <translation type="vanished">Totale: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>Commissione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Impossibile inviare denaro: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
@@ -2129,57 +2215,57 @@ Ring size: </source>
         <translation type="vanished">Denaro inviato correttamente</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Attendi...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>Impostazioni Programma</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">Totale</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>manda alla stessa destinazione</translation>
     </message>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -900,12 +900,12 @@
         <translation type="vanished">Clicca il bottone per mostrare il seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -918,17 +918,17 @@
         <translation type="vanished">E&apos; veramente importante che ti salvi queste parole in quanto sono l&apos;unico backup che serve per il tuo portafoglio.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Mostra seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -938,97 +938,97 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Password</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1037,17 +1037,17 @@
         <translation type="vanished">Indirizzo processo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
@@ -1097,6 +1097,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1135,6 +1140,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1233,24 +1243,24 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,6 +1277,11 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../pages/Transfer.qml" line="78"/>
         <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1346,122 +1361,128 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informazioni</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">Totale: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">Commissione: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Conferma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">Denaro inviato correttamente</translation>
     </message>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -900,12 +900,12 @@
         <translation type="vanished">Clicca il bottone per mostrare il seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -918,17 +918,17 @@
         <translation type="vanished">E&apos; veramente importante che ti salvi queste parole in quanto sono l&apos;unico backup che serve per il tuo portafoglio.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Mostra seed</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -938,97 +938,97 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Password</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1037,17 +1037,17 @@
         <translation type="vanished">Indirizzo processo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
@@ -1233,24 +1233,24 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1346,122 +1346,122 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Informazioni</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
+Number of transactions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
 Amount: </source>
         <translation type="unfinished">Totale: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">Commissione: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Conferma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">Denaro inviato correttamente</translation>
     </message>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -940,7 +940,7 @@
         <translation type="obsolete">ニーモニックシード: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished">シードを表示</translation>
     </message>
@@ -954,132 +954,132 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished">ホストネーム / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished">ポート</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">パスワード</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1253,7 +1253,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1339,141 +1339,141 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">情報</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 金額: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 手数料: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">送金に成功しました</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
@@ -82,9 +87,8 @@
         <translation type="vanished">説明 &lt;font size=&apos;2&apos;&gt;(ローカルなデータベース)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>新規</translation>
+        <translation type="vanished">新規</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -167,28 +171,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -308,8 +302,12 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>FILTER</source>
-        <translation>フィルタ</translation>
+        <translation type="vanished">フィルタ</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -542,105 +540,119 @@
         <translation type="unfinished">残高</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unlocked Balance:</source>
-        <translation type="unfinished">ロック解除された残高</translation>
+        <translation type="obsolete">ロック解除された残高</translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -648,27 +660,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>ネットワークの状態</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>接続されました</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>接続されていません</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -686,12 +703,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -699,30 +716,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>低</translation>
+        <translation type="vanished">低</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>中</translation>
+        <translation type="vanished">中</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>高</translation>
+        <translation type="vanished">高</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation type="unfinished">ブロックの同期中 %1/%2</translation>
+        <translation type="obsolete">ブロックの同期中 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished">ブロックの同期中</translation>
     </message>
@@ -791,7 +829,7 @@
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
+        <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -894,17 +932,15 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>Click button to show seed</source>
-        <translation type="unfinished">シードを表示するにはボタンをクリック</translation>
+        <translation type="obsolete">シードを表示するにはボタンをクリック</translation>
     </message>
     <message>
         <source>Mnemonic seed: </source>
         <translation type="obsolete">ニーモニックシード: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished">シードを表示</translation>
     </message>
@@ -913,133 +949,137 @@
         <translation type="obsolete">デーモンのアドレス</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished">ホストネーム / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished">ポート</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">パスワード</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,19 +1125,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1124,12 +1170,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1143,12 +1183,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1160,19 +1200,27 @@
         <translation type="vanished">低</translation>
     </message>
     <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">中</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">高</translation>
+    </message>
+    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>中</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>高</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1185,22 +1233,17 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>取引のプライオリティ</translation>
     </message>
@@ -1210,217 +1253,227 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">情報</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 金額: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 手数料: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">送金に成功しました</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1453,7 +1506,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    アドレス &lt;font size=&apos;2&apos;&gt;  (タイプするか、&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;アドレス帳&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; から選択してください )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ペイメントID &lt;font size=&apos;2&apos;&gt;( オプション )&lt;/font&gt;</translation>
     </message>
@@ -1462,9 +1515,8 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">説明 &lt;font size=&apos;2&apos;&gt;( オプション: 何か記述するとアドレス帳に保存されます )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>送金</translation>
+        <translation type="vanished">送金</translation>
     </message>
 </context>
 <context>
@@ -1526,7 +1578,7 @@ Please upgrade or connect to another daemon</source>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
+        <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1575,7 +1627,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,11 +1645,6 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1685,57 +1732,62 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">準備が完了しました!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished">テストネット</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished">復元するブロックの高さ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1747,43 +1799,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>モネロを使う</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1803,47 +1855,47 @@ Please upgrade or connect to another daemon</source>
         <translation type="obsolete">復元するブロックの高さ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>ウォレットが保存される場所</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>ディレクトリを選択してください</translation>
     </message>
@@ -1868,27 +1920,27 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>モネロへようこそ!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>以下のオプションの中から選択してください:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1910,7 +1962,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="obsolete">デーモンのアドレスを下記に指定してください</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished">テストネット</translation>
     </message>
@@ -1940,13 +1992,13 @@ Please upgrade or connect to another daemon</source>
         <translation type="obsolete">パスワードの確認</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1955,7 +2007,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished">パスワード</translation>
     </message>
@@ -1980,25 +2032,24 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">25個の秘密のキーワードを入力してください</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>ようこそ</translation>
+        <translation type="vanished">ようこそ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">モネロへようこそ!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>言語と地域フォーマットを選択してください。</translation>
     </message>
@@ -2006,19 +2057,19 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>ウォレットを開けませんでした: </translation>
     </message>
@@ -2027,109 +2078,151 @@ Please upgrade or connect to another daemon</source>
         <translation type="obsolete">ブロックを同期中 %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished">金額が不正です: %1から%2の範囲内としてください</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>取引データを作成できません: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">ロック解除された残高</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">残高</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please confirm transaction:
@@ -2140,14 +2233,14 @@ Amount: </source>
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 アドレス: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
@@ -2160,45 +2253,38 @@ Amount: </source>
 金額: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 手数料: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>送金できませんでした</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
@@ -2207,12 +2293,12 @@ Description: </source>
         <translation type="vanished">送金に成功しました</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished">お待ちください...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished">モネロ</translation>
     </message>
@@ -2221,7 +2307,7 @@ Description: </source>
         <translation type="vanished">ウォレットを初期化しています...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>プログラムセットアップウィザード</translation>
     </message>
@@ -2230,7 +2316,7 @@ Description: </source>
         <translation type="vanished">モネロ  -  寄付</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>同じ宛先に送金する</translation>
     </message>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -940,7 +940,7 @@
         <translation type="obsolete">ニーモニックシード: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished">シードを表示</translation>
     </message>
@@ -954,132 +954,132 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished">ホストネーム / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished">ポート</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">パスワード</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1129,6 +1129,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1167,6 +1172,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1253,7 +1263,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1304,6 +1314,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="175"/>
         <source>all</source>
         <translation type="unfinished"></translation>
@@ -1339,141 +1354,147 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">情報</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 金額: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 手数料: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">送金に成功しました</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -567,7 +567,7 @@
     <message>
         <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
-        <translation type="unfinished">(optioneel)</translation>
+        <translation>(optioneel)</translation>
     </message>
     <message>
         <location filename="../pages/Mining.qml" line="121"/>
@@ -627,7 +627,7 @@
     <message>
         <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
-        <translation type="unfinished"></translation>
+        <translation>Status:</translation>
     </message>
 </context>
 <context>
@@ -837,7 +837,7 @@
     </message>
     <message>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 of 64 hexadecimale karakters</translation>
+        <translation type="vanished">16 of 64 hexadecimale karakters</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -909,12 +909,12 @@
         <translation type="vanished">Klik op de knop om de hersteltekst te tonen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation>Onjuist wachtwoord</translation>
     </message>
@@ -927,12 +927,12 @@
         <translation type="vanished">Het is erg belangrijk om dit op te schrijven, omdat dit de enige back-up is die u heeft voor uw portemonnee.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Toon hersteltekst</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Node-adres</translation>
     </message>
@@ -946,121 +946,121 @@
         <translation type="vanished">Sluit huidige portemonnee en open de configuratie-assistent</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Portemonnee sluiten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation>Maak een alleen-lezen portomonnee aan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation>Node beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
-        <translation>Start node</translation>
+        <translation>Start lokale node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
-        <translation>Stop node</translation>
+        <translation>Stop lokale node</translation>
     </message>
     <message>
         <source>Show log</source>
         <translation type="vanished">Bekijk log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation>Node log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Hostnaam / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation>Bekijk status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation>Node start argumenten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation>Loginnaam (optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation>Opmaak instellingen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation>Aangepaste decoraties</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation>Log niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(b.v. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation>GUI versie:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation>Ingebouwde Monero versie:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation>Portomonnee hersteltekst</translation>
     </message>
@@ -1270,7 +1270,7 @@
         <translation type="vanished">Privacy niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
@@ -1362,151 +1362,151 @@
     <message>
         <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
-        <translation>Opgeslagen in lokale portomonnee historie</translation>
+        <translation>Wordt opgeslagen in de lokale portomonnee historie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation>Laat geavanceerde opties zien</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
-        <translatorcomment>Lastig te vertalen deze. Misschien heeft iemand anders een beter idee.</translatorcomment>
-        <translation>Schoonvegen van niet-te-mengen posten</translation>
+        <translatorcomment>Lastig te vertalen deze. Misschien heeft iemand anders een beter idee dan, &quot;Schoonvegen van niet-te-mengen posten&quot;</translatorcomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation>Doorzoek uitgaven</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation>Fout:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation>Met success the uitgaven doorzocht</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Het laden van de niet-ondertekende transactie, is mislukt:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transactie #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation>
 Ontvanger:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation>
 Betaal-ID:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgrootte:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan transactie niet insturen:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation>Geld is succesvol verstuurd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portomonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbonden node is niet compatible met de GUI. 
 Graag updaten of verbind met een andere node</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -21,12 +21,12 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="71"/>
         <source>QRCODE</source>
-        <translation type="unfinished"></translation>
+        <translation>QRCODE</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="93"/>
         <source>4...</source>
-        <translation type="unfinished"></translation>
+        <translation>4...</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="102"/>
@@ -41,12 +41,12 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Paste 64 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Plak 64 hexadecimale karakters</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="125"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneell)&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="127"/>
@@ -56,27 +56,27 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="138"/>
         <source>Give this entry a name or description</source>
-        <translation type="unfinished"></translation>
+        <translation>Geef deze vermelding een naam of omschrijving</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="153"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Toevoegen</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
-        <translation type="unfinished">Fout</translation>
+        <translation>Fout</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="161"/>
         <source>Invalid address</source>
-        <translation type="unfinished"></translation>
+        <translation>Ongeldig adres</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="165"/>
         <source>Can&apos;t create entry</source>
-        <translation type="unfinished"></translation>
+        <translation>Kan vermelding niet opslaan</translation>
     </message>
     <message>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
@@ -136,7 +136,7 @@
     <message>
         <location filename="../components/DaemonConsole.qml" line="108"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Afsluiten</translation>
     </message>
     <message>
         <location filename="../components/DaemonConsole.qml" line="119"/>
@@ -161,17 +161,17 @@
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="84"/>
         <source>Starting Monero daemon in %1 seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Monero node wordt gestart in %1 seconde(n)</translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="106"/>
         <source>Start daemon (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Start node (%1)</translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="123"/>
         <source>Use custom settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruik aangepaste instellingen</translation>
     </message>
 </context>
 <context>
@@ -255,7 +255,7 @@
     <message>
         <location filename="../pages/History.qml" line="273"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Filteren</translation>
     </message>
     <message>
         <source>Incremental search</source>
@@ -355,17 +355,17 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="270"/>
         <source>(%1/10 confirmations)</source>
-        <translation type="unfinished"></translation>
+        <translation>(%1/10 bevestigingen)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="274"/>
         <source>UNCONFIRMED</source>
-        <translation type="unfinished"></translation>
+        <translation>ONBEVESTIGD</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="275"/>
         <source>PENDING</source>
-        <translation type="unfinished"></translation>
+        <translation>IN AFWACHTING</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="304"/>
@@ -418,7 +418,7 @@
     <message>
         <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
-        <translation type="unfinished"></translation>
+        <translation>R</translation>
     </message>
     <message>
         <source>Verify payment</source>
@@ -427,7 +427,7 @@
     <message>
         <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
-        <translation type="unfinished"></translation>
+        <translation>K</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="326"/>
@@ -437,42 +437,43 @@
     <message>
         <location filename="../LeftPanel.qml" line="277"/>
         <source>Address book</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresboek</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="278"/>
         <source>B</source>
-        <translation type="unfinished"></translation>
+        <translation>B</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
-        <translation type="unfinished"></translation>
+        <translation>H</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="349"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Geavanceerd</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="350"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation>D</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="371"/>
         <source>Mining</source>
+        <translatorcomment>Wat is een juiste vertaling voor minen/mining? Winning misschien, zoals het winnen van delfstoffen. Of ontginning/ontginnen?</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="372"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation>M</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="395"/>
         <source>Check payment</source>
-        <translation type="unfinished"></translation>
+        <translation>Betaling controleren</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="419"/>
@@ -482,7 +483,7 @@
     <message>
         <location filename="../LeftPanel.qml" line="420"/>
         <source>I</source>
-        <translation type="unfinished"></translation>
+        <translation>I</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="442"/>
@@ -492,12 +493,12 @@
     <message>
         <location filename="../LeftPanel.qml" line="443"/>
         <source>E</source>
-        <translation type="unfinished"></translation>
+        <translation>E</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
-        <translation type="unfinished"></translation>
+        <translation>S</translation>
     </message>
 </context>
 <context>
@@ -513,12 +514,12 @@
     <message>
         <location filename="../MiddlePanel.qml" line="45"/>
         <source>Balance</source>
-        <translation type="unfinished">Saldo</translation>
+        <translation>Saldo</translation>
     </message>
     <message>
         <location filename="../MiddlePanel.qml" line="47"/>
         <source>Unlocked Balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschikbaar Saldo</translation>
     </message>
 </context>
 <context>
@@ -566,7 +567,7 @@
     <message>
         <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">(optioneel)</translation>
     </message>
     <message>
         <location filename="../pages/Mining.qml" line="121"/>
@@ -644,7 +645,7 @@
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="53"/>
         <source>Synchronizing</source>
-        <translation type="unfinished"></translation>
+        <translation>Synchroniseren</translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="57"/>
@@ -702,17 +703,17 @@
     <message>
         <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
         <source>Low</source>
-        <translation type="unfinished"></translation>
+        <translation>Laag</translation>
     </message>
     <message>
         <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation>Gemiddeld</translation>
     </message>
     <message>
         <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
         <source>High</source>
-        <translation type="unfinished"></translation>
+        <translation>Hoog</translation>
     </message>
 </context>
 <context>
@@ -724,12 +725,12 @@
     <message>
         <location filename="../components/ProgressBar.qml" line="43"/>
         <source>Establishing connection...</source>
-        <translation type="unfinished"></translation>
+        <translation>Bezig met verbinding te maken...</translation>
     </message>
     <message>
         <location filename="../components/ProgressBar.qml" line="57"/>
         <source>Blocks remaining: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Blokken resterend: %1</translation>
     </message>
     <message>
         <location filename="../components/ProgressBar.qml" line="100"/>
@@ -802,7 +803,7 @@
     <message>
         <location filename="../pages/Receive.qml" line="219"/>
         <source>16 hexadecimal characters</source>
-        <translation type="unfinished"></translation>
+        <translation>16 hexadecimale karakters</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="258"/>
@@ -812,22 +813,22 @@
     <message>
         <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
-        <translation>AlleenLezen portemonnee geïntegreerd adres wordt hier weergegeven</translation>
+        <translation>Alleen-lezen portemonnee geïntegreerd adres wordt hier weergegeven</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="370"/>
         <source>Save QrCode</source>
-        <translation type="unfinished"></translation>
+        <translation>QR-Code opslaan</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="371"/>
         <source>Failed to save QrCode to </source>
-        <translation type="unfinished"></translation>
+        <translation>Opslaan van QR-Code is mislukt</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="382"/>
         <source>Save As</source>
-        <translation type="unfinished"></translation>
+        <translation>Opslaan als</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="211"/>
@@ -836,7 +837,7 @@
     </message>
     <message>
         <source>16 or 64 hexadecimal characters</source>
-        <translation type="vanished">16 of 64 hexadecimale karakters</translation>
+        <translation>16 of 64 hexadecimale karakters</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -952,7 +953,7 @@
     <message>
         <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Maak een alleen-lezen portomonnee aan</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="133"/>
@@ -986,17 +987,17 @@
     <message>
         <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
-        <translation type="unfinished"></translation>
+        <translation>Bekijk status</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
+        <translation>Node start argumenten</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
-        <translation type="unfinished"></translation>
+        <translation>(optioneel)</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="237"/>
@@ -1006,17 +1007,17 @@
     <message>
         <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
-        <translation type="unfinished"></translation>
+        <translation>Loginnaam (optioneel)</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruikersnaam</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
-        <translation type="unfinished">Wachtwoord</translation>
+        <translation>Wachtwoord</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="273"/>
@@ -1026,42 +1027,42 @@
     <message>
         <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Opmaak instellingen</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
-        <translation type="unfinished"></translation>
+        <translation>Aangepaste decoraties</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
-        <translation type="unfinished"></translation>
+        <translation>Log niveau</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
-        <translation type="unfinished"></translation>
+        <translation>(b.v. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Versie</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
-        <translation type="unfinished"></translation>
+        <translation>GUI versie:</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Ingebouwde Monero versie:</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee hersteltekst</translation>
     </message>
 </context>
 <context>
@@ -1106,24 +1107,24 @@
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
         <source>Sign</source>
-        <translation type="unfinished"></translation>
+        <translation>Signeer</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecteer</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifiëer</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Handtekening adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of slecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
         <source>SIGN</source>
@@ -1206,17 +1207,17 @@
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation>Normaal</translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation>Gemiddeld</translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
-        <translation type="unfinished"></translation>
+        <translation>Hoog</translation>
     </message>
 </context>
 <context>
@@ -1284,98 +1285,100 @@
     <message>
         <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
-        <translation type="unfinished"></translation>
+        <translation>OpenAlias fout</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="78"/>
         <source>Privacy level (ringsize %1)</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Is &apos;vertrouwenscirkel grootte&apos; een betere vertaling?</translatorcomment>
+        <translation>Privacy niveau (ring grootte %1)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="175"/>
         <source>all</source>
-        <translation type="unfinished"></translation>
+        <translation>alles</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="193"/>
         <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Laag (x1 vergoeding)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="194"/>
         <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Gemiddeld (x20 vergoeding)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="195"/>
         <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Hoog (x166 vergoeding)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="223"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="241"/>
         <source>QR Code</source>
-        <translation type="unfinished"></translation>
+        <translation>QR-Code</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="271"/>
         <source>Resolve</source>
-        <translation type="unfinished"></translation>
+        <translation>Oplossen</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
-        <translation type="unfinished"></translation>
+        <translation>Geen geldig adres gevonden onder dit OpenAlias adres</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
-        <translation type="unfinished"></translation>
+        <translation>Adres gevonden, maar DNSSEC handtekeningen konden niet geverifiëerd worden, dus het adres kan mogelijk gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
-        <translation type="unfinished"></translation>
+        <translation>Geen geldig adres gevonden onder het opgegeven OpenAlias adres, en de DNSSEC handtekeningen konden niet geverifiëerd worden, dus het adres kan mogelijk gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="299"/>
         <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
-        <translation type="unfinished"></translation>
+        <translation>Interne fout</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
-        <translation type="unfinished"></translation>
+        <translation>Geen adres gevonden</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;( Optioneel )&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
-        <translation type="unfinished"></translation>
+        <translation>Opgeslagen in lokale portomonnee historie</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
-        <translation type="unfinished">Verzenden</translation>
+        <translation>Verzenden</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Laat geavanceerde opties zien</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Lastig te vertalen deze. Misschien heeft iemand anders een beter idee.</translatorcomment>
+        <translation>Schoonvegen van niet-te-mengen posten</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="500"/>
@@ -1395,95 +1398,99 @@
     <message>
         <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Doorzoek uitgaven</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="560"/>
         <location filename="../pages/Transfer.qml" line="595"/>
         <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
-        <translation type="unfinished">Fout</translation>
+        <translation>Fout</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
-        <translation type="unfinished"></translation>
+        <translation>Fout:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="566"/>
         <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
-        <translation type="unfinished">Informatie</translation>
+        <translation>Informatie</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished"></translation>
+        <translation>Met success the uitgaven doorzocht</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
+        <translation>Het laden van de niet-ondertekende transactie, is mislukt:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
-        <translation type="unfinished">
+        <translation>
 Aantal transacties:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>
+Transactie #%1</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
-        <translation type="unfinished"></translation>
+        <translation>
+Ontvanger:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
-        <translation type="unfinished"></translation>
+        <translation>
+Betaal-ID:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
-        <translation type="unfinished">
+        <translation>
 Bedrag: </translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
-        <translation type="unfinished">
+        <translation>
 Vergoeding: </translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
-        <translation type="unfinished"></translation>
+        <translation>
+Ringgrootte:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
-        <translation type="unfinished">Bevestiging</translation>
+        <translation>Bevestiging</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
-        <translation type="unfinished"></translation>
+        <translation>Kan transactie niet insturen:</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
-        <translation type="unfinished"></translation>
+        <translation>Geld is succesvol verstuurd</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="705"/>
@@ -1559,7 +1566,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
-        <translation type="unfinished"></translation>
+        <translation>Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -1589,7 +1596,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../pages/TxKey.qml" line="212"/>
         <source>Check</source>
-        <translation type="unfinished"></translation>
+        <translation>Controleren</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="181"/>
@@ -1648,7 +1655,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Maak een alleen-lezen portomonnee aan</translation>
     </message>
 </context>
 <context>
@@ -1664,7 +1671,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Maak een nieuwe portomonnee aan</translation>
     </message>
 </context>
 <context>
@@ -1732,12 +1739,12 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee naam</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Hersteltekst</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="61"/>
@@ -1762,12 +1769,12 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nieuwe portomonnee gegevens:</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="82"/>
         <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vergeet u hersteltekst niet op te schrijven. U kunt u hersteltekst bekijken en instellingen aanpassen op de instellingen pagina.</translation>
     </message>
     <message>
         <source>An overview of your Monero configuration is below:</source>
@@ -1803,28 +1810,29 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee maken</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
-        <translation type="unfinished"></translation>
+        <translation>Geslaagd</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>De alleen-lezen portomonnee is aangemaakt. U kunt deze openen door de huidige portomonnee te sluiten, klik vervolgens op &quot;Open een portomonnee vanaf een bestand&quot;, en selecteer de alleen-lezen portomonnee in: 
+%1</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
-        <translation type="unfinished">Fout</translation>
+        <translation>Fout</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Afbreken</translation>
     </message>
 </context>
 <context>
@@ -1844,37 +1852,37 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee naam</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Herstel met behulp van hersteltekst</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Herstel met behulp van sleutels</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee adres (openbaar)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
-        <translation type="unfinished"></translation>
+        <translation>Aleen-lezen sleutel (privé)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bestedings-sleutel (privé)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
-        <translation type="unfinished"></translation>
+        <translation>Herstelpunt (optioneel)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
@@ -1900,12 +1908,12 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
         <source>Enter your 25 word mnemonic seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Vul u hersteltekst van 25 woorden in</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Deze hersteltekst is &lt;b&gt;zeer&lt;/b&gt; belangerijk om veilig op te slaag en privé te houden. Het is het enigste wat u (nodig) heeft om uw portomonnee te backuppen of te herstellen.</translation>
     </message>
 </context>
 <context>
@@ -1923,22 +1931,22 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Maak een nieuwe portomonnee aan</translation>
     </message>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Herstel een portomonnee met behulp van u hersteltekst of sleutels</translation>
     </message>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
-        <translation type="unfinished"></translation>
+        <translation>Open een portomonnee vanaf een bestand</translation>
     </message>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="262"/>
         <source>Custom daemon address (optional)</source>
-        <translation type="unfinished"></translation>
+        <translation>Aangepast node-adres (optioneel)</translation>
     </message>
     <message>
         <source>This is my first time, I want to create a new account</source>
@@ -1990,13 +1998,14 @@ Graag updaten of verbind met een andere node</translation>
         <location filename="../wizard/WizardPassword.qml" line="57"/>
         <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
-        <translation type="unfinished"></translation>
+        <translation>Beveilig u portomonnee met een wachtwoord</translation>
     </message>
     <message>
         <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
-        <translation type="unfinished"></translation>
+        <translation>Let op: dit wachtwoord kan niet hersteld worden. Als u het wachtwoord vergeet, kan de portomonnee alleen hersteld worden worden met u hersteltekst van 25 woorden.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Vul een sterk wachtwoord in&lt;/b&gt; (gebruik letters, cijfers, en/of symbolen):</translation>
     </message>
 </context>
 <context>
@@ -2004,12 +2013,12 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
-        <translation type="unfinished">Wachtwoord</translation>
+        <translation>Wachtwoord</translation>
     </message>
     <message>
         <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
         <source>Confirm password</source>
-        <translation type="unfinished">Wachtwoord bevestigen</translation>
+        <translation>Wachtwoord bevestigen</translation>
     </message>
 </context>
 <context>
@@ -2025,7 +2034,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
         <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Portomonnee herstellen</translation>
     </message>
 </context>
 <context>
@@ -2037,7 +2046,7 @@ Graag updaten of verbind met een andere node</translation>
     <message>
         <location filename="../wizard/WizardWelcome.qml" line="79"/>
         <source>Welcome to Monero!</source>
-        <translation type="unfinished">Welkom bij Monero!</translation>
+        <translation>Welkom bij Monero!</translation>
     </message>
     <message>
         <location filename="../wizard/WizardWelcome.qml" line="89"/>
@@ -2079,6 +2088,7 @@ Graag updaten of verbind met een andere node</translation>
         <location filename="../main.qml" line="599"/>
         <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
+        <translatorcomment>Lastig te vertalen, iemand een beter idéé?</translatorcomment>
         <translation type="unfinished">Er zijn geen, niet te mengen, posten gevonden, die opgeschoond moesten worden</translation>
     </message>
     <message>
@@ -2161,17 +2171,17 @@ Omschrijving:</translation>
     <message>
         <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (waiting for block)</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschikbaar saldo (wachten op blok)</translation>
     </message>
     <message>
         <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschikbaar saldo (~%1 min)</translation>
     </message>
     <message>
         <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
-        <translation type="unfinished">Beschikbaar saldo</translation>
+        <translation>Beschikbaar saldo</translation>
     </message>
     <message>
         <location filename="../main.qml" line="395"/>
@@ -2186,12 +2196,12 @@ Omschrijving:</translation>
     <message>
         <location filename="../main.qml" line="426"/>
         <source>Daemon failed to start</source>
-        <translation type="unfinished"></translation>
+        <translation>Het starten van de node is mislukt</translation>
     </message>
     <message>
         <location filename="../main.qml" line="427"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
-        <translation type="unfinished"></translation>
+        <translation>Graag u portomonnee en node log controleren op fouten. U kunt ook proberen %1 handmatig te starten.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="501"/>
@@ -2232,12 +2242,14 @@ Vergoeding: </translation>
         <source>
 
 Ringsize: </source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+Ringgrootte:</translation>
     </message>
     <message>
         <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
-        <translation>onvoldoende balans. Beschikbaar saldo: %1</translation>
+        <translation>onvoldoende saldo. Beschikbaar saldo: %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="652"/>
@@ -2252,22 +2264,22 @@ Ringsize: </source>
     <message>
         <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Transactie opgeslagen naar bestand: %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
-        <translation type="unfinished"></translation>
+        <translation>Did adres heeft %1 monero ontvangen, met %2 bevestiging(en).</translation>
     </message>
     <message>
         <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Saldo (synchroniseren)</translation>
     </message>
     <message>
         <location filename="../main.qml" line="727"/>
         <source>Balance</source>
-        <translation type="unfinished">Saldo</translation>
+        <translation>Saldo</translation>
     </message>
     <message>
         <location filename="../main.qml" line="933"/>
@@ -2282,7 +2294,7 @@ Ringsize: </source>
     <message>
         <location filename="../main.qml" line="977"/>
         <source>Monero</source>
-        <translation type="unfinished"></translation>
+        <translation>Monero</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1018"/>
@@ -2292,22 +2304,22 @@ Ringsize: </source>
     <message>
         <location filename="../main.qml" line="1270"/>
         <source>Daemon is running</source>
-        <translation type="unfinished"></translation>
+        <translation>Node is gestart</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1271"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Node zal nog steeds in de achtergrond blijven lopen als de GUI gesloten is.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1273"/>
         <source>Stop daemon</source>
-        <translation type="unfinished">Stop node</translation>
+        <translation>Stop node</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1308"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Nieuwe monero-wallet-gu versiei is beschikbaar: %1&lt;br&gt;%2</translation>
     </message>
 </context>
 </TS>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -909,12 +909,12 @@
         <translation type="vanished">Klik op de knop om de hersteltekst te tonen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Onjuist wachtwoord</translation>
     </message>
@@ -927,12 +927,12 @@
         <translation type="vanished">Het is erg belangrijk om dit op te schrijven, omdat dit de enige back-up is die u heeft voor uw portemonnee.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Toon hersteltekst</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Node-adres</translation>
     </message>
@@ -946,27 +946,27 @@
         <translation type="vanished">Sluit huidige portemonnee en open de configuratie-assistent</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Portemonnee sluiten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation>Maak een alleen-lezen portomonnee aan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Node beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Start lokale node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Stop lokale node</translation>
     </message>
@@ -975,92 +975,92 @@
         <translation type="vanished">Bekijk log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Node log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Hostnaam / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation>Bekijk status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation>Node start argumenten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation>Loginnaam (optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation>Opmaak instellingen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation>Aangepaste decoraties</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation>Log niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(b.v. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation>GUI versie:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation>Ingebouwde Monero versie:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation>Portomonnee hersteltekst</translation>
     </message>
@@ -1110,6 +1110,11 @@
         <translation>Signeer</translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation>Kies een bestand om te signeren</translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1120,6 +1125,11 @@
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
         <translation>Verifiëer</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
+        <translation>Kies een bestand om te verifiëren</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="444"/>
@@ -1270,7 +1280,7 @@
         <translation type="vanished">Privacy niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
@@ -1292,6 +1302,11 @@
         <source>Privacy level (ringsize %1)</source>
         <translatorcomment>Is &apos;vertrouwenscirkel grootte&apos; een betere vertaling?</translatorcomment>
         <translation>Privacy niveau (ring grootte %1)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start lokale node&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="175"/>
@@ -1365,148 +1380,158 @@
         <translation>Wordt opgeslagen in de lokale portomonnee historie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation>Laat geavanceerde opties zien</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <source>Privacy level (ringsize 5)</source>
+        <translation type="vanished">Privacy niveau (ring grootte 5)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translatorcomment>Lastig te vertalen deze. Misschien heeft iemand anders een beter idee dan, &quot;Schoonvegen van niet-te-mengen posten&quot;</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation>Doorzoek uitgaven</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation>Fout:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation>Met success the uitgaven doorzocht</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation>Kies een bestand</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Het laden van de niet-ondertekende transactie, is mislukt:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transactie #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation>
 Ontvanger:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation>
 Betaal-ID:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgrootte:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan transactie niet insturen:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation>Geld is succesvol verstuurd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portomonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbonden node is niet compatible met de GUI. 
 Graag updaten of verbind met een andere node</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -4,55 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>Voeg nieuw contact toe</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;Betaal-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Een unieke gebruikersnaam dat gebruikt wordt in&lt;br/&gt;het adresboek. Het wordt niet gebruik voor&lt;br/&gt;het verzenden van informatie</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">Fout</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>Beschrijving &lt;font size=&apos;2&apos;&gt;(Lokale database)&lt;/font&gt;</translation>
+        <translation type="vanished">Beschrijving &lt;font size=&apos;2&apos;&gt;(Lokale database)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>NIEUW</translation>
+        <translation type="vanished">NIEUW</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>Betaal-ID</translation>
+        <translation type="vanished">Betaal-ID</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>Beschrijving</translation>
+        <translation type="vanished">Beschrijving</translation>
     </message>
 </context>
 <context>
@@ -92,21 +132,46 @@
     </message>
 </context>
 <context>
+    <name>DaemonConsole</name>
+    <message>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
         <source>Daemon doesn&apos;t appear to be running</source>
-        <translation>Node lijkt niet actief te zijn</translation>
+        <translation type="vanished">Node lijkt niet actief te zijn</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
         <source>Start daemon</source>
-        <translation>Node starten</translation>
+        <translation type="vanished">Node starten</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
         <source>Cancel</source>
-        <translation>Annuleren</translation>
+        <translation type="vanished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -188,6 +253,11 @@
         <translation>&lt;b&gt;Totaalbedrag van geselecteerde betalingen&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
         <translation type="vanished">Incrementeel zoeken</translation>
     </message>
@@ -216,9 +286,8 @@
         <translation>Naar</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="273"/>
         <source>FILTER</source>
-        <translation>FILTEREN</translation>
+        <translation type="vanished">FILTEREN</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -243,58 +312,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="67"/>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>Geen verdere resultaten</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>Betaal-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation>Transactie-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation>Transactiesleutel:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation>Transactienotitie:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="50"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
         <source>Destinations:</source>
         <translation>Bestemmingen:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="99"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>Blokhoogte:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>Vergoeding</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
@@ -302,78 +386,116 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>Ontvangen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>Betaling controleren</translation>
+        <translation type="vanished">Betaling controleren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
         <source>Sign/verify</source>
         <translation>Signeren/verifiëren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="395"/>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
@@ -381,40 +503,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="204"/>
         <source>Balance:</source>
-        <translation>Saldo:</translation>
+        <translation type="vanished">Saldo:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="242"/>
         <source>Unlocked Balance:</source>
-        <translation>Beschikbaar Saldo:</translation>
+        <translation type="vanished">Beschikbaar Saldo:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Netwerkstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Onjuiste versie</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Ongeldige verbindingsstatus</translation>
     </message>
@@ -422,22 +665,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="77"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>Portemonnee wachtwoord invullen</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="77"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Portemonnee wachtwoord invullen voor:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="152"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="167"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -445,30 +688,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>LAAG</translation>
+        <translation type="vanished">LAAG</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>GEMIDDELD</translation>
+        <translation type="vanished">GEMIDDELD</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>HOOG</translation>
+        <translation type="vanished">HOOG</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation>Blokken synchroniseren %1/%2</translation>
+        <translation type="vanished">Blokken synchroniseren %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation>Blokken synchroniseren</translation>
     </message>
@@ -536,24 +800,43 @@
         <translation>Alleen-lezen portomonnee adres is hier weergegeven</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="211"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Geïntegreerd adres</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="220"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>AlleenLezen portemonnee geïntegreerd adres wordt hier weergegeven</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="244"/>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>Betaal-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="252"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 of 64 hexadecimale karakters</translation>
+        <translation type="vanished">16 of 64 hexadecimale karakters</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -577,7 +860,7 @@
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een simpele verkoop tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik hier om een willekeurig betaal-ID te maken voor een nieuwe klant&lt;/p&gt; &lt;p&gt;Laat je klant de QR code scannen om een betaling uit te voeren (als die klant over software beschikt die QR codes kan scannen).&lt;/p&gt;&lt;p&gt;Deze pagina zal automatisch de blockchain en transactiepoel controleren voor inkomende transacties met behulp van deze QR code. Als je een bedrag invuld, zal er ook gecontroleerd worden of het complete bedrag ontvangen is.&lt;/p&gt;Het is aan jou om eventuele onbevestigde transacties te accepter of niet. Het is zeer waarschijnlijk dat deze op korte termijn bevestigd zullen zijn, maar er is altijd een mogelijkheid dat dit niet zo is. Het is dus bij grote bedragen aan te raden, te wachten op één of meer bevestigingen.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="277"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>Genereer</translation>
     </message>
@@ -621,95 +904,164 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="50"/>
-        <location filename="../pages/Settings.qml" line="117"/>
         <source>Click button to show seed</source>
-        <translation>Klik op de knop om de hersteltekst te tonen</translation>
+        <translation type="vanished">Klik op de knop om de hersteltekst te tonen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="69"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="70"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Onjuist wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="99"/>
         <source>Mnemonic seed: </source>
-        <translation>Hersteltekst:</translation>
+        <translation type="vanished">Hersteltekst:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="146"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Het is erg belangrijk om dit op te schrijven, omdat dit de enige back-up is die u heeft voor uw portemonnee.</translation>
+        <translation type="vanished">Het is erg belangrijk om dit op te schrijven, omdat dit de enige back-up is die u heeft voor uw portemonnee.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="159"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Toon hersteltekst</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="189"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Node-adres</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Portemonnee beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="258"/>
         <source>Close current wallet and open wizard</source>
-        <translation>Sluit huidige portemonnee en open de configuratie-assistent</translation>
+        <translation type="vanished">Sluit huidige portemonnee en open de configuratie-assistent</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="269"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Portemonnee sluiten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Node beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="295"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Start node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Stop node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="325"/>
         <source>Show log</source>
-        <translation>Bekijk log</translation>
+        <translation type="vanished">Bekijk log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="345"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Node log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="198"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Hostnaam / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="207"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -753,8 +1105,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>SIGNEREN</translation>
+        <translation type="vanished">SIGNEREN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -763,10 +1136,8 @@
         <translation>Of bestand:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>SELECTEER</translation>
+        <translation type="vanished">SELECTEER</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -792,10 +1163,8 @@
         <translation>Het te verifiëren bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>VERIFIËREN</translation>
+        <translation type="vanished">VERIFIËREN</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -803,20 +1172,19 @@
         <translation>Bestand met bericht om te verifiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Handtekening adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adres&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;boek )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Handtekening adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adres&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;boek )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -824,30 +1192,42 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>LAAG</translation>
+        <translation type="vanished">LAAG</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">GEMIDDELD</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">HOOG</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>GEMIDDELD</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>HOOG</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="64"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="74"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Transactie prioriteit</translation>
     </message>
@@ -869,60 +1249,257 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="113"/>
         <source>or ALL</source>
-        <translation>of ALLES</translation>
+        <translation type="vanished">of ALLES</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="129"/>
         <source>LOW (x1 fee)</source>
-        <translation>LAAG (x1 vergoeding)</translation>
+        <translation type="vanished">LAAG (x1 vergoeding)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="130"/>
         <source>MEDIUM (x20 fee)</source>
-        <translation>GEMIDDELD (x20 vergoeding)</translation>
+        <translation type="vanished">GEMIDDELD (x20 vergoeding)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="131"/>
         <source>HIGH (x166 fee)</source>
-        <translation>HOOG (x166 vergoeding)</translation>
+        <translation type="vanished">HOOG (x166 vergoeding)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="160"/>
         <source>Privacy level</source>
-        <translation>Privacy niveau</translation>
+        <translation type="vanished">Privacy niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="186"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="200"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="253"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional - saved to local wallet history )&lt;/font&gt;</source>
-        <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;( Optioneel - opgeslagen in de portomonnee historie )&lt;/font&gt;</translation>
+        <translation type="vanished">Omschrijving &lt;font size=&apos;2&apos;&gt;( Optioneel - opgeslagen in de portomonnee historie )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="384"/>
-        <location filename="../pages/Transfer.qml" line="390"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Verzenden</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">Fout</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">Informatie</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished">
+Aantal transacties:</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished">
+Bedrag: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">
+Vergoeding: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Bevestiging</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portomonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="393"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbonden node is niet compatible met de GUI. 
 Graag updaten of verbind met een andere node</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="398"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>
@@ -931,12 +1508,12 @@ Graag updaten of verbind met een andere node</translation>
         <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; kiezen )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="228"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;( Optioneel )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="240"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 of 64 hexadecimale karakters</translation>
     </message>
@@ -945,14 +1522,12 @@ Graag updaten of verbind met een andere node</translation>
         <translation type="vanished">Beschrijving &lt;font size=&apos;2&apos;&gt;(Een optionele beschrijving die opgeslagen wordt in het lokale adresboek)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="301"/>
         <source>SEND</source>
-        <translation>VERZENDEN</translation>
+        <translation type="vanished">VERZENDEN</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="327"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation type="unfinished">SCHOONVEGEN VAN NIET TE MENGEN POSTEN</translation>
+        <translation type="obsolete">SCHOONVEGEN VAN NIET TE MENGEN POSTEN</translation>
     </message>
 </context>
 <context>
@@ -978,9 +1553,13 @@ Graag updaten of verbind met een andere node</translation>
         <translation> - de geheime transactie sleutel, verstrekt door de verzender</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="106"/>
         <source>If a payment had several transactions then each must must be checked and the results combined.</source>
-        <translation>Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
+        <translation type="vanished">Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -1008,14 +1587,18 @@ Graag updaten of verbind met een andere node</translation>
         <translation>Plak een transactiesleutel</translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation>Transactie sleutel</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
         <source>CHECK</source>
-        <translation>CONTROLE</translation>
+        <translation type="vanished">CONTROLE</translation>
     </message>
 </context>
 <context>
@@ -1061,16 +1644,27 @@ Graag updaten of verbind met een andere node</translation>
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>A new wallet has been created for you</source>
-        <translation>Een nieuwe portemonnee is voor u aangemaakt</translation>
+        <translation type="vanished">Een nieuwe portemonnee is voor u aangemaakt</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>Dit is de hersteltekst bestaande uit 25 woorden voor uw portemonnee</translation>
+        <translation type="vanished">Dit is de hersteltekst bestaande uit 25 woorden voor uw portemonnee</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1109,58 +1703,75 @@ Graag updaten of verbind met een andere node</translation>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>Portemonnee naam</translation>
+        <translation type="vanished">Portemonnee naam</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>Hersteltekst</translation>
+        <translation type="vanished">Hersteltekst</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Portemonnee locatie</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Node adres</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Herstelpunt (blokhoogte)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An overview of your Monero configuration is below:</source>
-        <translation>Een overzicht van uw Monero configuratie staat hieronder:</translation>
+        <translation type="vanished">Een overzicht van uw Monero configuratie staat hieronder:</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
@@ -1175,44 +1786,103 @@ Graag updaten of verbind met een andere node</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="153"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Een portemonnee met dezelfde naam bestaat reeds. Verander alstublieft de naam van uw portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="161"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Niet-ASCII tekens zijn niet toegestaan in het portomonnee pad of portemonnee naam</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="361"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>GEBRUIK MONERO</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">Fout</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>Dit is de naam van uw portemonnee. U kunt de naam veranderen mocht u dat willen:</translation>
+        <translation type="vanished">Dit is de naam van uw portemonnee. U kunt de naam veranderen mocht u dat willen:</translation>
     </message>
     <message>
         <source>My account name</source>
         <translation type="vanished">Mijn portemonnee naam:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>Herstelpunt (blokhoogte)</translation>
+        <translation type="vanished">Herstelpunt (blokhoogte)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Uw portemonnee is opgeslagen in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Kies een locatie</translation>
     </message>
@@ -1224,45 +1894,70 @@ Graag updaten of verbind met een andere node</translation>
         <translation type="vanished">Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee. Op de volgende pagina wordt gevraagd om de hersteltekst te bevestigen om ervoor te zorgen dat de tekst op de juiste manier is overgenomen.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee..</translation>
+        <translation type="vanished">Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee..</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Welkom bij Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Selecteer alstublieft een van de volgende opties:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>Dit is mijn eerste keer, ik wil een nieuwe portemonnee aanmaken</translation>
+        <translation type="vanished">Dit is mijn eerste keer, ik wil een nieuwe portemonnee aanmaken</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>Ik wil mijn portemonnee herstellen met de 25 woorden hersteltekst</translation>
+        <translation type="vanished">Ik wil mijn portemonnee herstellen met de 25 woorden hersteltekst</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>Ik wil een portemonnee openen vanuit een bestand</translation>
+        <translation type="vanished">Ik wil een portemonnee openen vanuit een bestand</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>Stel hieronder alstublieft het node adres in.</translation>
+        <translation type="vanished">Stel hieronder alstublieft het node adres in.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1270,55 +1965,82 @@ Graag updaten of verbind met een andere node</translation>
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
+        <translation type="vanished">Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
+        <translation type="vanished">Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="144"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>Het wachtwoord kan niet hersteld worden, mocht u het wachtwoord vergeten dan moet u uw portemonnee herstellen via de 25 woorden hersteltekst die u zojuist heeft gekregen&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">Het wachtwoord kan niet hersteld worden, mocht u het wachtwoord vergeten dan moet u uw portemonnee herstellen via de 25 woorden hersteltekst die u zojuist heeft gekregen&lt;br/&gt;&lt;br/&gt;
                         Uw wachtwoord wordt gebruikt om uw portemonnee te openen en acties te bevestigen, dus zorg ervoor dat uw wachtwoord voldoende veilig is.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="158"/>
         <source>Password</source>
-        <translation>Wachtwoord</translation>
+        <translation type="vanished">Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="171"/>
         <source>Confirm password</source>
-        <translation>Wachtwoord bevestigen</translation>
+        <translation type="vanished">Wachtwoord bevestigen</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">Wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">Wachtwoord bevestigen</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="92"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>Uw portemonnee kan hersteld worden</translation>
+        <translation type="vanished">Uw portemonnee kan hersteld worden</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="93"/>
         <source>Please enter your 25 word private key</source>
-        <translation>Vult u alstublieft de 25 woorden hersteltekst in</translation>
+        <translation type="vanished">Vult u alstublieft de 25 woorden hersteltekst in</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Welkom</translation>
+        <translation type="vanished">Welkom</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Welkom bij Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Selecteer alstublieft een taal en regio.</translation>
     </message>
@@ -1326,19 +2048,19 @@ Graag updaten of verbind met een andere node</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="233"/>
-        <location filename="../main.qml" line="374"/>
-        <location filename="../main.qml" line="435"/>
-        <location filename="../main.qml" line="446"/>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="551"/>
-        <location filename="../main.qml" line="580"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="234"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Portemonnee kan niet geopend worden: </translation>
     </message>
@@ -1347,29 +2069,29 @@ Graag updaten of verbind met een andere node</translation>
         <translation type="vanished">Synchroniseren van blok %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transactie kan niet worden aangemaakt: Verkeerde node versie: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
-        <location filename="../main.qml" line="387"/>
-        <location filename="../main.qml" line="479"/>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished">Er zijn geen, niet te mengen, posten gevonden, die opgeschoond moesten worden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Gelieve de transactie te bevestigen:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="403"/>
-        <location filename="../main.qml" line="494"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1378,23 +2100,22 @@ Amount: </source>
 Bedrag:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="405"/>
         <source>
 
 Mixin: </source>
-        <translation type="unfinished">
+        <translation type="obsolete">
 
 Menging:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="406"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -1403,66 +2124,90 @@ Description: </source>
 Omschrijving:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="436"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Bedrag is verkeerd: aantal tussen %1 en %2 verwacht</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="527"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Het geld is met success verzonden: %1 transactie(s)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Betaling controleren</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Dit adres heeft %1 monero ontvangen, maar de transactie is nog niet verwerkt</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="572"/>
         <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>Dit adres heeft %1 monero ontvangen, met %2 bevestigingen</translation>
+        <translation type="vanished">Dit adres heeft %1 monero ontvangen, met %2 bevestigingen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Dit adres heeft niets ontvangen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="378"/>
-        <location filename="../main.qml" line="471"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Transactie kan niet worden aangemaakt: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="315"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">Beschikbaar saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation>Wachten tot de node gestart is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="320"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Wachten tot de node gestopt is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="492"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="401"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Adres:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
@@ -1475,41 +2220,94 @@ Amount: </source>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="404"/>
-        <location filename="../main.qml" line="495"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="447"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>onvoldoende balans. Beschikbaar saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Geld kon niet worden verstuurd:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">Saldo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Even geduld aub…</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
-        <translation type="vanished">Installatie - Assistent</translation>
+        <translation>Installatie - Assistent</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="977"/>
+        <source>Monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>naar hetzelfde adres verzenden</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished">Stop node</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
@@ -78,9 +83,8 @@
         <translation type="vanished">Opis &lt;font size=&apos;2&apos;&gt;(Lokalna baza danych)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
         <source>ADD</source>
-        <translation>DODAJ</translation>
+        <translation type="vanished">DODAJ</translation>
     </message>
     <message>
         <source>Payment ID</source>
@@ -143,28 +147,30 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
         <source>Daemon doesn&apos;t appear to be running</source>
-        <translation>Proces nie został uruchomiony</translation>
+        <translation type="vanished">Proces nie został uruchomiony</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
         <source>Start daemon</source>
-        <translation>Uruchom proces</translation>
+        <translation type="vanished">Uruchom proces</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
         <source>Cancel</source>
-        <translation>Anuluj</translation>
+        <translation type="vanished">Anuluj</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -253,8 +259,12 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>FILTER</source>
-        <translation>FILTRUJ</translation>
+        <translation type="vanished">FILTRUJ</translation>
     </message>
     <message>
         <location filename="../pages/History.qml" line="310"/>
@@ -480,105 +490,119 @@
         <translation type="unfinished">Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unlocked Balance:</source>
-        <translation>Dostępne saldo:</translation>
+        <translation type="vanished">Dostępne saldo:</translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -586,27 +610,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>Status sieci</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>Połączono</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>Nieprawidłowa wersja</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>Rozłączono</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>Nieprawidłowy status połączenia</translation>
     </message>
@@ -624,12 +653,12 @@
         <translation>Podaj hasło dla portefela:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -637,30 +666,51 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>Niski</translation>
+        <translation type="vanished">Niski</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>Średni</translation>
+        <translation type="vanished">Średni</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>Wysoki</translation>
+        <translation type="vanished">Wysoki</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
         <source>Synchronizing blocks %1/%2</source>
-        <translation>Synchronizowanie bloków %1/%2</translation>
+        <translation type="vanished">Synchronizowanie bloków %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronizowanie bloków</translation>
     </message>
@@ -728,6 +778,11 @@
         <translation>Adres portfela tylko do odczytu</translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>Adres zintegrowany</translation>
@@ -758,9 +813,8 @@
         <translation>Identyfikator płatności</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="219"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 lub 64 znaków szesnastkowych</translation>
+        <translation type="vanished">16 lub 64 znaków szesnastkowych</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="291"/>
@@ -828,24 +882,16 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
         <source>Click button to show seed</source>
-        <translation>Kliknij przycisk by zobaczyć klucz</translation>
+        <translation type="vanished">Kliknij przycisk by zobaczyć klucz</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Nieprawidłowe hasło</translation>
     </message>
@@ -858,17 +904,17 @@
         <translation type="vanished">Te słowa są niezwykle istotne. Zapisz je. To jedyne co potrzebujesz, by odzyskać portfel.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Pokaż klucz 25 słowny</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Adres procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Zarządzaj portfelem</translation>
     </message>
@@ -877,107 +923,121 @@
         <translation type="vanished">Zamknij ten portfel i otwórz kreator</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Zamknij portfel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Zarządzaj procesem</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Uruchom proces</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Zatrzymaj proces</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
         <source>Show log</source>
-        <translation>Pokaż log</translation>
+        <translation type="vanished">Pokaż log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">Hasło</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Log procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
@@ -1023,8 +1083,24 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>PODPISZ</translation>
+        <translation type="vanished">PODPISZ</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -1033,10 +1109,8 @@
         <translation>Lub plik:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>WYBIERZ</translation>
+        <translation type="vanished">WYBIERZ</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -1062,10 +1136,8 @@
         <translation>Wiadomość do potwierdzenia</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>POTWIERDŹ</translation>
+        <translation type="vanished">POTWIERDŹ</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -1085,12 +1157,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
@@ -1102,30 +1174,38 @@
         <translation type="vanished">NISKI</translation>
     </message>
     <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">ŚREDNI</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">WYSOKI</translation>
+    </message>
+    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>ŚREDNI</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>WYSOKI</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>Wartość</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>Priorytet transakcji</translation>
     </message>
@@ -1139,245 +1219,269 @@
         <translation type="vanished">WSZYSTKO</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
         <source>LOW (x1 fee)</source>
-        <translation>NISKI (prowizja x1)</translation>
+        <translation type="vanished">NISKI (prowizja x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
         <source>MEDIUM (x20 fee)</source>
-        <translation>ŚREDNI (prowizja x20)</translation>
+        <translation type="vanished">ŚREDNI (prowizja x20)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
         <source>HIGH (x166 fee)</source>
-        <translation>WYSOKI (prowizja x166)</translation>
+        <translation type="vanished">WYSOKI (prowizja x166)</translation>
     </message>
     <message>
         <source>Privacy level</source>
         <translation type="vanished">Poziom prywatności</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Koszt transakcji</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Wklej lub wybierz z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Ksiązki adresowej&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Wklej lub wybierz z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Ksiązki adresowej&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional - saved to local wallet history )&lt;/font&gt;</source>
         <translation type="vanished">Opis &lt;font size=&apos;2&apos;&gt;(Opcjonalny - przechowywany lokalnie w historii portfela)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Potrfel nie jest podłączony do procesu.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Połączony proces nie jest kompatybilny z interfejsem graficznym.
 Uaktualnij go lub podłącz się do innego procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Poczekaj na zakończenie synchronizacji procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Identyfikator płatności &lt;font size=&apos;2&apos;&gt;(Opcjonalny)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 lub 64 znaków szesnastkowych</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
         <source>SEND</source>
-        <translation>WYŚLIJ</translation>
+        <translation type="vanished">WYŚLIJ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
+        <source>SWEEP UNMIXABLE</source>
+        <translation type="vanished">MIESZAJ</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
-        <translation>MIESZAJ</translation>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">Wyślij</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Liczba transakcji: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1434,6 +1538,11 @@ Ring size: </source>
         <translation>Wklej klucz tx</translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation>Klucz transakcji</translation>
@@ -1444,9 +1553,8 @@ Ring size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
         <source>CHECK</source>
-        <translation>SPRAWDŹ</translation>
+        <translation type="vanished">SPRAWDŹ</translation>
     </message>
 </context>
 <context>
@@ -1490,7 +1598,7 @@ Ring size: </source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1508,11 +1616,6 @@ Ring size: </source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1552,21 +1655,21 @@ Ring size: </source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>Włączony</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>Wyłączony</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
@@ -1579,38 +1682,43 @@ Ring size: </source>
         <translation type="vanished">Źródło</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>Ścieżka portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>Adres procesu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>Sieć testowa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>Odzyskaj wysokość</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1626,43 +1734,43 @@ Ring size: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Portfel o takiej nazwie istenieje. Podaj inną nazwę</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>W nazwie portfela lub konta użyte niedozwolone znaki</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>UŻYJ MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,47 +1786,47 @@ Ring size: </source>
         <translation type="vanished">Odzyskaj wysokość</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>Twoj portfel został zachowany w</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>Wybierz katalog</translation>
     </message>
@@ -1743,27 +1851,27 @@ Ring size: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>Witaj w świecie Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>Wybierz jedną z opcji:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1789,7 +1897,7 @@ Ring size: </source>
         <translation type="vanished">Proszę podaj adres procesu.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Śieć testowa</translation>
     </message>
@@ -1819,13 +1927,13 @@ Ring size: </source>
         <translation type="vanished">Potwierdź hasło</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1834,7 +1942,7 @@ Ring size: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished">Hasło</translation>
     </message>
@@ -1855,25 +1963,24 @@ Ring size: </source>
         <translation type="vanished">Wprowadź swój 25 słowny klucz prywatny</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Witaj</translation>
+        <translation type="vanished">Witaj</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">Witaj w świecie Monero!</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Wybierz język i region.</translation>
     </message>
@@ -1881,46 +1988,46 @@ Ring size: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Nie można otworzyć portfela: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nie można zrealizować transakcji: Zła wersja procesu: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Brak niemiksowalnych wyjść do zmieszania</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>Potwierdź transakcję:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1937,13 +2044,13 @@ Mixin: </source>
 Domieszka: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>Liczba transakcji: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -1952,123 +2059,158 @@ Description: </source>
 Opis: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Wartość nieprawidłowa: oczekiwano liczby od %1 do %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nie można zrealizować transakcji:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">Dostępne saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation>Czekam na start procesu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Czekam na zakończenie procesu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 Adres: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
 Identyfikator płatności: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished">Zatrzymaj proces</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>niewystarczające środki: Dostępne saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Nie mogę przesłać pieniędzy: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>Informacja</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>Proszę czekać...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Pomyślne przesłane pieniędzy, liczba transakcji: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>Sprawdź płatność</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Ten adres otrzymał %1 monero, ale transakcja nie została jeszcze wykopana</translation>
     </message>
@@ -2077,22 +2219,22 @@ Ring size: </source>
         <translation type="vanished">Adres otrzymal %1 monero, liczba potwierdzeń: %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>Ten adres nic nie otrzymał</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>wyślij do tego samego celu</translation>
     </message>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -886,12 +886,12 @@
         <translation type="vanished">Kliknij przycisk by zobaczyć klucz</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation>Nieprawidłowe hasło</translation>
     </message>
@@ -904,12 +904,12 @@
         <translation type="vanished">Te słowa są niezwykle istotne. Zapisz je. To jedyne co potrzebujesz, by odzyskać portfel.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>Pokaż klucz 25 słowny</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>Adres procesu</translation>
     </message>
@@ -923,27 +923,27 @@
         <translation type="vanished">Zamknij ten portfel i otwórz kreator</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>Zamknij portfel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation>Zarządzaj procesem</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation>Uruchom proces</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation>Zatrzymaj proces</translation>
     </message>
@@ -952,92 +952,92 @@
         <translation type="vanished">Pokaż log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">Hasło</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation>Log procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>Host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
@@ -1087,6 +1087,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1096,6 +1101,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1235,7 +1245,7 @@
         <translation type="vanished">Poziom prywatności</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>Koszt transakcji</translation>
     </message>
@@ -1248,20 +1258,20 @@
         <translation type="vanished">Opis &lt;font size=&apos;2&apos;&gt;(Opcjonalny - przechowywany lokalnie w historii portfela)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Potrfel nie jest podłączony do procesu.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Połączony proces nie jest kompatybilny z interfejsem graficznym.
 Uaktualnij go lub podłącz się do innego procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Poczekaj na zakończenie synchronizacji procesu</translation>
     </message>
@@ -1269,6 +1279,11 @@ Uaktualnij go lub podłącz się do innego procesu</translation>
         <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Identyfikator płatności &lt;font size=&apos;2&apos;&gt;(Opcjonalny)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="66"/>
@@ -1365,123 +1380,129 @@ Uaktualnij go lub podłącz się do innego procesu</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">Wyślij</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Liczba transakcji: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -886,12 +886,12 @@
         <translation type="vanished">Kliknij przycisk by zobaczyć klucz</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation>Nieprawidłowe hasło</translation>
     </message>
@@ -904,12 +904,12 @@
         <translation type="vanished">Te słowa są niezwykle istotne. Zapisz je. To jedyne co potrzebujesz, by odzyskać portfel.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>Pokaż klucz 25 słowny</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>Adres procesu</translation>
     </message>
@@ -923,27 +923,27 @@
         <translation type="vanished">Zamknij ten portfel i otwórz kreator</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>Zamknij portfel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation>Zarządzaj procesem</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation>Uruchom proces</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation>Zatrzymaj proces</translation>
     </message>
@@ -952,92 +952,92 @@
         <translation type="vanished">Pokaż log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">Hasło</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation>Log procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>Host / IP</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
@@ -1235,7 +1235,7 @@
         <translation type="vanished">Poziom prywatności</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>Koszt transakcji</translation>
     </message>
@@ -1248,20 +1248,20 @@
         <translation type="vanished">Opis &lt;font size=&apos;2&apos;&gt;(Opcjonalny - przechowywany lokalnie w historii portfela)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Potrfel nie jest podłączony do procesu.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Połączony proces nie jest kompatybilny z interfejsem graficznym.
 Uaktualnij go lub podłącz się do innego procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Poczekaj na zakończenie synchronizacji procesu</translation>
     </message>
@@ -1365,123 +1365,123 @@ Uaktualnij go lub podłącz się do innego procesu</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">Wyślij</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished">Liczba transakcji: </translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
+Number of transactions: </source>
+        <translation type="unfinished">Liczba transakcji: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -59,6 +59,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/AddressBook.qml" line="158"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -71,11 +76,6 @@
     <message>
         <location filename="../pages/AddressBook.qml" line="165"/>
         <source>Can&apos;t create entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="153"/>
-        <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -131,28 +131,18 @@
 <context>
     <name>DaemonManagerDialog</name>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="65"/>
-        <source>Daemon doesn&apos;t appear to be running</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="90"/>
-        <source>Start daemon</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="107"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="120"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="129"/>
-        <source>(optional)</source>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -241,7 +231,7 @@
     </message>
     <message>
         <location filename="../pages/History.qml" line="273"/>
-        <source>FILTER</source>
+        <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -459,105 +449,115 @@
         <translation type="unfinished">Баланс</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="251"/>
-        <source>Unlocked Balance:</source>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="79"/>
+        <location filename="../pages/Mining.qml" line="72"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="79"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="92"/>
+        <location filename="../pages/Mining.qml" line="85"/>
         <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="86"/>
         <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="94"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="95"/>
+        <location filename="../pages/Mining.qml" line="88"/>
         <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="89"/>
         <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="106"/>
+        <location filename="../pages/Mining.qml" line="99"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="122"/>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="131"/>
+        <location filename="../pages/Mining.qml" line="156"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="141"/>
+        <location filename="../pages/Mining.qml" line="166"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="167"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="144"/>
+        <location filename="../pages/Mining.qml" line="169"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="156"/>
+        <location filename="../pages/Mining.qml" line="181"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="198"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="184"/>
+        <location filename="../pages/Mining.qml" line="209"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="187"/>
+        <location filename="../pages/Mining.qml" line="212"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="189"/>
+        <location filename="../pages/Mining.qml" line="214"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -565,27 +565,32 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
-        <source>Wrong version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
-        <source>Disconnected</source>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <source>Wrong version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -603,12 +608,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="145"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="160"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
@@ -616,30 +621,35 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
-        <source>LOW</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
-        <source>MEDIUM</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
-        <source>HIGH</source>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="87"/>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -707,6 +717,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
@@ -734,11 +749,6 @@
     <message>
         <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="219"/>
-        <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -807,144 +817,142 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>Click button to show seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="52"/>
-        <location filename="../pages/Settings.qml" line="133"/>
-        <source>View only wallets doesn&apos;t have a mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="455"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="290"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="76"/>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="107"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="168"/>
-        <source>This is very important to write down and keep secret. It is all you need to restore your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="208"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="222"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
-        <source>Show log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="248"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="268"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="276"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="338"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="366"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="392"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="408"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="431"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="441"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="299"/>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="308"/>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="316"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -990,19 +998,25 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
-        <source>SIGN</source>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Or file:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
-        <source>SELECT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1029,12 +1043,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
-        <source>VERIFY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="408"/>
         <source>Filename with message to verify</source>
         <translation type="unfinished"></translation>
@@ -1048,12 +1056,12 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="109"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="126"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1062,29 +1070,29 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>NORMAL</source>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
+        <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
+        <source>High</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="122"/>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="132"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1094,235 +1102,235 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="187"/>
-        <source>LOW (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="188"/>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="189"/>
-        <source>HIGH (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="241"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="693"/>
         <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="708"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="713"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="352"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="65"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="77"/>
-        <source>Privacy level (ring size %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="171"/>
-        <source>ALL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="273"/>
-        <source>QRCODE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
-        <source>RESOLVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="289"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="328"/>
+        <location filename="../pages/Transfer.qml" line="296"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="331"/>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="337"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="364"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="377"/>
+        <location filename="../pages/Transfer.qml" line="345"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="389"/>
+        <location filename="../pages/Transfer.qml" line="357"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="417"/>
-        <source>SEND</source>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="459"/>
-        <source>Advanced</source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
-        <source>SWEEP UNMIXABLE</source>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="488"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="510"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="524"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="539"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
-Ring size: </source>
+Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1375,6 +1383,11 @@ Ring size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/TxKey.qml" line="181"/>
         <source>Transaction key</source>
         <translation type="unfinished"></translation>
@@ -1382,11 +1395,6 @@ Ring size: </source>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="212"/>
-        <source>CHECK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1431,7 +1439,7 @@ Ring size: </source>
 <context>
     <name>WizardCreateViewOnlyWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="83"/>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1441,11 +1449,6 @@ Ring size: </source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
         <source>Create a new wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
-        <source>Here is your wallet&apos;s 25 word mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1485,57 +1488,62 @@ Ring size: </source>
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Backup seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
         <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1547,43 +1555,43 @@ Ring size: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="157"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="165"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="370"/>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="388"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="398"/>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="407"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="421"/>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1591,47 +1599,47 @@ Ring size: </source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="135"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="151"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="165"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="198"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
         <source>View key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="234"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
         <source>Restore height (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="247"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1652,27 +1660,27 @@ Ring size: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="90"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="102"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="151"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="188"/>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="227"/>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,7 +1690,7 @@ Ring size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="287"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1690,13 +1698,13 @@ Ring size: </source>
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
-        <location filename="../wizard/WizardPassword.qml" line="56"/>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
         <source>Give your wallet a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="135"/>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
         <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1705,7 +1713,7 @@ Ring size: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="69"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1718,25 +1726,24 @@ Ring size: </source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="111"/>
-        <source>Restore wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
-        <source>Enter your 25 word mnemonic seed:</source>
+        <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>Добро пожаловать</translation>
+        <translation type="vanished">Добро пожаловать</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>Пожалуйста выберите язык и региональный формат.</translation>
     </message>
@@ -1744,198 +1751,233 @@ Ring size: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="301"/>
-        <location filename="../main.qml" line="440"/>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="554"/>
-        <location filename="../main.qml" line="615"/>
-        <location filename="../main.qml" line="653"/>
-        <location filename="../main.qml" line="682"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="302"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="452"/>
-        <location filename="../main.qml" line="453"/>
-        <location filename="../main.qml" line="563"/>
-        <location filename="../main.qml" line="564"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="466"/>
-        <location filename="../main.qml" line="577"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
-        <location filename="../main.qml" line="578"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="472"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="473"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
-        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="333"/>
+        <location filename="../main.qml" line="343"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="395"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="388"/>
+        <location filename="../main.qml" line="401"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="467"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="468"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="470"/>
-        <location filename="../main.qml" line="579"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="471"/>
-        <source>
-
-Ring size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="616"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="674"/>
+        <location filename="../main.qml" line="711"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="727"/>
         <source>Balance</source>
         <translation type="unfinished">Баланс</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="625"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="664"/>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="911"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="926"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="967"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -817,22 +817,22 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -842,117 +842,117 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1102,24 +1102,24 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1215,122 +1215,122 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
-        <source>
-Number of transactions: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
-        <source>
-Transaction #%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
-        <source>
-Recipient: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
-        <source>
-payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="608"/>
         <source>
-Amount: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
-        <source>
-Fee: </source>
+Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="610"/>
         <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="611"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="612"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="613"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="614"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="615"/>
+        <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -817,22 +817,22 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -842,117 +842,117 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1002,6 +1002,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1040,6 +1045,11 @@
     <message>
         <location filename="../pages/Sign.qml" line="334"/>
         <source>Message to verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1102,24 +1112,24 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1180,6 +1190,11 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="175"/>
         <source>all</source>
         <translation type="unfinished"></translation>
@@ -1215,122 +1230,128 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_zh.ts
+++ b/translations/monero-core_zh.ts
@@ -896,132 +896,132 @@
         <translation type="vanished">請注意這是唯一需要備份的錢包資訊，請一定要抄寫下來。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="102"/>
+        <location filename="../pages/Settings.qml" line="103"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="119"/>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>顯示種子碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="131"/>
+        <location filename="../pages/Settings.qml" line="133"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="148"/>
+        <location filename="../pages/Settings.qml" line="150"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="162"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="177"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="195"/>
+        <location filename="../pages/Settings.qml" line="197"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="203"/>
+        <location filename="../pages/Settings.qml" line="205"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="217"/>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>區塊鏈同步程式位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="226"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>主機名稱 / IP位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="235"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>通訊埠</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="245"/>
+        <location filename="../pages/Settings.qml" line="247"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="254"/>
+        <location filename="../pages/Settings.qml" line="256"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="263"/>
+        <location filename="../pages/Settings.qml" line="265"/>
         <source>Password</source>
         <translation type="unfinished">密碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="271"/>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="298"/>
+        <location filename="../pages/Settings.qml" line="300"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="315"/>
+        <location filename="../pages/Settings.qml" line="317"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="326"/>
+        <location filename="../pages/Settings.qml" line="328"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="352"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="368"/>
+        <location filename="../pages/Settings.qml" line="370"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="384"/>
+        <location filename="../pages/Settings.qml" line="386"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="391"/>
+        <location filename="../pages/Settings.qml" line="393"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="401"/>
+        <location filename="../pages/Settings.qml" line="403"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="412"/>
+        <location filename="../pages/Settings.qml" line="414"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="420"/>
+        <location filename="../pages/Settings.qml" line="422"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="423"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1035,7 +1035,7 @@
         <translation type="vanished">關閉當前的錢包然後啟動設定精靈</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="87"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>關閉錢包</translation>
     </message>
@@ -1085,6 +1085,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Sign.qml" line="195"/>
+        <source>Please choose a file to sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Sign.qml" line="208"/>
         <location filename="../pages/Sign.qml" line="393"/>
         <source>Select</source>
@@ -1094,6 +1099,11 @@
         <location filename="../pages/Sign.qml" line="352"/>
         <location filename="../pages/Sign.qml" line="426"/>
         <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="380"/>
+        <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1208,6 +1218,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/Transfer.qml" line="44"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>金額</translation>
@@ -1289,140 +1304,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="387"/>
+        <location filename="../pages/Transfer.qml" line="385"/>
         <source>Send</source>
         <translation type="unfinished">付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="442"/>
+        <location filename="../pages/Transfer.qml" line="437"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="491"/>
+        <location filename="../pages/Transfer.qml" line="486"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="505"/>
+        <location filename="../pages/Transfer.qml" line="500"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="527"/>
+        <location filename="../pages/Transfer.qml" line="522"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="536"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="565"/>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <location filename="../pages/Transfer.qml" line="656"/>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="561"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="662"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Information</source>
         <translation type="unfinished">資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="572"/>
+        <location filename="../pages/Transfer.qml" line="567"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="601"/>
+        <location filename="../pages/Transfer.qml" line="584"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 交易數量: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="605"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="612"/>
+        <location filename="../pages/Transfer.qml" line="607"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="613"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="614"/>
+        <location filename="../pages/Transfer.qml" line="609"/>
         <source>
 Fee: </source>
         <translation type="unfinished">手續費: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="615"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="629"/>
+        <location filename="../pages/Transfer.qml" line="624"/>
         <source>Confirmation</source>
         <translation type="unfinished">確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="652"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="710"/>
-        <location filename="../pages/Transfer.qml" line="722"/>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="720"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="730"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1473,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">隱私等級</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>交易所需的花費</translation>
     </message>

--- a/translations/monero-core_zh.ts
+++ b/translations/monero-core_zh.ts
@@ -896,132 +896,132 @@
         <translation type="vanished">請注意這是唯一需要備份的錢包資訊，請一定要抄寫下來。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="102"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
+        <location filename="../pages/Settings.qml" line="119"/>
         <source>Show seed</source>
         <translation>顯示種子碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="133"/>
+        <location filename="../pages/Settings.qml" line="131"/>
         <source>Manage daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="150"/>
+        <location filename="../pages/Settings.qml" line="148"/>
         <source>Start daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="164"/>
+        <location filename="../pages/Settings.qml" line="162"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="175"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="197"/>
+        <location filename="../pages/Settings.qml" line="195"/>
         <source>Daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="205"/>
+        <location filename="../pages/Settings.qml" line="203"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="219"/>
+        <location filename="../pages/Settings.qml" line="217"/>
         <source>Daemon address</source>
         <translation>區塊鏈同步程式位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="228"/>
+        <location filename="../pages/Settings.qml" line="226"/>
         <source>Hostname / IP</source>
         <translation>主機名稱 / IP位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="237"/>
+        <location filename="../pages/Settings.qml" line="235"/>
         <source>Port</source>
         <translation>通訊埠</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="247"/>
+        <location filename="../pages/Settings.qml" line="245"/>
         <source>Login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="254"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
+        <location filename="../pages/Settings.qml" line="263"/>
         <source>Password</source>
         <translation type="unfinished">密碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="273"/>
+        <location filename="../pages/Settings.qml" line="271"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="300"/>
+        <location filename="../pages/Settings.qml" line="298"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="317"/>
+        <location filename="../pages/Settings.qml" line="315"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="328"/>
+        <location filename="../pages/Settings.qml" line="326"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="354"/>
+        <location filename="../pages/Settings.qml" line="352"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="370"/>
+        <location filename="../pages/Settings.qml" line="368"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="386"/>
+        <location filename="../pages/Settings.qml" line="384"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="393"/>
+        <location filename="../pages/Settings.qml" line="391"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="403"/>
+        <location filename="../pages/Settings.qml" line="401"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="414"/>
+        <location filename="../pages/Settings.qml" line="412"/>
         <source>Wallet mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="422"/>
+        <location filename="../pages/Settings.qml" line="420"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="423"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1035,7 +1035,7 @@
         <translation type="vanished">關閉當前的錢包然後啟動設定精靈</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="87"/>
         <source>Close wallet</source>
         <translation>關閉錢包</translation>
     </message>
@@ -1289,140 +1289,140 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="385"/>
+        <location filename="../pages/Transfer.qml" line="387"/>
         <source>Send</source>
         <translation type="unfinished">付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="437"/>
+        <location filename="../pages/Transfer.qml" line="442"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="486"/>
+        <location filename="../pages/Transfer.qml" line="491"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="500"/>
+        <location filename="../pages/Transfer.qml" line="505"/>
         <source>create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="522"/>
+        <location filename="../pages/Transfer.qml" line="527"/>
         <source>sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="536"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
         <source>submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>Rescan spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
-        <location filename="../pages/Transfer.qml" line="595"/>
-        <location filename="../pages/Transfer.qml" line="651"/>
+        <location filename="../pages/Transfer.qml" line="565"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
+        <location filename="../pages/Transfer.qml" line="656"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
-        <location filename="../pages/Transfer.qml" line="657"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="662"/>
         <source>Information</source>
         <translation type="unfinished">資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
+        <location filename="../pages/Transfer.qml" line="572"/>
         <source>Sucessfully rescanned spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="608"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 交易數量: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="605"/>
+        <location filename="../pages/Transfer.qml" line="610"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="606"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="612"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="613"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="614"/>
         <source>
 Fee: </source>
         <translation type="unfinished">手續費: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="610"/>
+        <location filename="../pages/Transfer.qml" line="615"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="624"/>
+        <location filename="../pages/Transfer.qml" line="629"/>
         <source>Confirmation</source>
         <translation type="unfinished">確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="652"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="663"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="705"/>
-        <location filename="../pages/Transfer.qml" line="717"/>
+        <location filename="../pages/Transfer.qml" line="710"/>
+        <location filename="../pages/Transfer.qml" line="722"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="725"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="725"/>
+        <location filename="../pages/Transfer.qml" line="730"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1452,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="vanished">隱私等級</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="465"/>
+        <location filename="../pages/Transfer.qml" line="470"/>
         <source>Transaction cost</source>
         <translation>交易所需的花費</translation>
     </message>

--- a/translations/monero-core_zh.ts
+++ b/translations/monero-core_zh.ts
@@ -4,55 +4,95 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="47"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Add new entry</source>
         <translation>增加付款位址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
-        <location filename="../pages/AddressBook.qml" line="173"/>
+        <location filename="../pages/AddressBook.qml" line="60"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="58"/>
+        <location filename="../pages/AddressBook.qml" line="62"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="77"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
+        <source>QRCODE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="93"/>
+        <source>4...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>付款 ID &lt;font size=&apos;2&apos;&gt;(可選填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="79"/>
+        <location filename="../pages/AddressBook.qml" line="104"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;付款 ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;在位址簿裡&lt;br/&gt;用以區分的使用者名稱&lt;br/&gt;這不是付款時&lt;br/&gt;傳送的資訊</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
-        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation>描述 &lt;font size=&apos;2&apos;&gt;(本地資訊)&lt;/font&gt;</translation>
+        <location filename="../pages/AddressBook.qml" line="116"/>
+        <source>Paste 64 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="101"/>
+        <location filename="../pages/AddressBook.qml" line="125"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="138"/>
+        <source>Give this entry a name or description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="153"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="158"/>
+        <source>Error</source>
+        <translation type="unfinished">錯誤</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="161"/>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="165"/>
+        <source>Can&apos;t create entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
+        <translation type="vanished">描述 &lt;font size=&apos;2&apos;&gt;(本地資訊)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="127"/>
         <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
         <source>ADD</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="174"/>
         <source>Payment ID</source>
-        <translation>付款 ID</translation>
+        <translation type="vanished">付款 ID</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="175"/>
         <source>Description</source>
-        <translation>標記</translation>
+        <translation type="vanished">標記</translation>
     </message>
 </context>
 <context>
@@ -92,16 +132,45 @@
     </message>
 </context>
 <context>
-    <name>DaemonProgress</name>
+    <name>DaemonConsole</name>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="44"/>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation>同步區塊中 %1 / %2</translation>
+        <location filename="../components/DaemonConsole.qml" line="108"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/DaemonProgress.qml" line="87"/>
+        <location filename="../components/DaemonConsole.qml" line="119"/>
+        <source>command + enter (e.g help)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonManagerDialog</name>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="84"/>
+        <source>Starting Monero daemon in %1 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="106"/>
+        <source>Start daemon (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/DaemonManagerDialog.qml" line="123"/>
+        <source>Use custom settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DaemonProgress</name>
+    <message>
+        <source>Synchronizing blocks %1/%2</source>
+        <translation type="vanished">同步區塊中 %1 / %2</translation>
+    </message>
+    <message>
         <source>Synchronizing blocks</source>
-        <translation>同步區塊中</translation>
+        <translation type="vanished">同步區塊中</translation>
     </message>
 </context>
 <context>
@@ -163,57 +232,63 @@
         <translation>&lt;b&gt;選擇的付款總金額&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="181"/>
+        <location filename="../pages/History.qml" line="182"/>
+        <source>Type for incremental search...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/History.qml" line="273"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Incremental search</source>
-        <translation>新增搜尋條件</translation>
+        <translation type="vanished">新增搜尋條件</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
         <source>Search transfers for a given string</source>
-        <translation>以關鍵字搜尋付款紀錄</translation>
+        <translation type="vanished">以關鍵字搜尋付款紀錄</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="194"/>
         <source>Type search string</source>
-        <translation>輸入搜尋關鍵字</translation>
+        <translation type="vanished">輸入搜尋關鍵字</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="234"/>
+        <location filename="../pages/History.qml" line="222"/>
         <source>Date from</source>
         <translation>日期從</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="236"/>
-        <location filename="../pages/History.qml" line="261"/>
-        <location filename="../pages/History.qml" line="343"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="224"/>
+        <location filename="../pages/History.qml" line="249"/>
+        <location filename="../pages/History.qml" line="331"/>
+        <location filename="../pages/History.qml" line="366"/>
+        <location filename="../pages/History.qml" line="398"/>
         <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="259"/>
-        <location filename="../pages/History.qml" line="408"/>
+        <location filename="../pages/History.qml" line="247"/>
+        <location filename="../pages/History.qml" line="396"/>
         <source>To</source>
         <translation>到</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="285"/>
         <source>FILTER</source>
-        <translation>篩選</translation>
+        <translation type="vanished">篩選</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="322"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Advanced filtering</source>
         <translation>進階篩選</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="341"/>
+        <location filename="../pages/History.qml" line="329"/>
         <source>Type of transaction</source>
         <translation>交易種類</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="364"/>
         <source>Amount from</source>
         <translation>金額從</translation>
     </message>
@@ -221,53 +296,73 @@
 <context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="46"/>
+        <location filename="../components/HistoryTable.qml" line="48"/>
         <source>Tx ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="47"/>
-        <location filename="../components/HistoryTable.qml" line="193"/>
+        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="204"/>
         <source>Payment ID:</source>
         <translation>付款ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Tx note:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="66"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
         <translation>沒有更多了</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="97"/>
+        <location filename="../components/HistoryTable.qml" line="110"/>
         <source>Details</source>
         <translation>細節</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="229"/>
+        <location filename="../components/HistoryTable.qml" line="255"/>
         <source>BlockHeight:</source>
         <translation>區塊高度:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="269"/>
+        <location filename="../components/HistoryTable.qml" line="270"/>
+        <source>(%1/10 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="274"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="275"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="304"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="330"/>
+        <location filename="../components/HistoryTable.qml" line="364"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="365"/>
+        <location filename="../components/HistoryTable.qml" line="400"/>
         <source>Fee</source>
         <translation>手續費</translation>
     </message>
@@ -275,78 +370,116 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="112"/>
+        <location filename="../LeftPanel.qml" line="116"/>
         <source>Balance</source>
         <translation>餘額</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="115"/>
+        <location filename="../LeftPanel.qml" line="119"/>
         <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="160"/>
         <source>Unlocked balance</source>
         <translation>總餘額</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="150"/>
+        <location filename="../LeftPanel.qml" line="163"/>
         <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="231"/>
+        <location filename="../LeftPanel.qml" line="252"/>
         <source>Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="232"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="254"/>
+        <location filename="../LeftPanel.qml" line="302"/>
         <source>Receive</source>
         <translation>收款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="255"/>
+        <location filename="../LeftPanel.qml" line="303"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="275"/>
         <source>Verify payment</source>
-        <translation>確認交易</translation>
+        <translation type="vanished">確認交易</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="276"/>
+        <location filename="../LeftPanel.qml" line="396"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="298"/>
+        <location filename="../LeftPanel.qml" line="326"/>
         <source>History</source>
         <translation>歷史紀錄</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="299"/>
+        <location filename="../LeftPanel.qml" line="277"/>
+        <source>Address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="278"/>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="327"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="374"/>
-        <source>Sign/verify</source>
-        <translation>簽署 / 驗證</translation>
+        <location filename="../LeftPanel.qml" line="349"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="375"/>
-        <location filename="../LeftPanel.qml" line="396"/>
-        <source>S</source>
+        <location filename="../LeftPanel.qml" line="350"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="371"/>
+        <source>Mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="372"/>
+        <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="395"/>
+        <source>Check payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="419"/>
+        <source>Sign/verify</source>
+        <translation>簽署 / 驗證</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="443"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="253"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="420"/>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="442"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -354,40 +487,161 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="193"/>
         <source>Balance:</source>
-        <translation>總餘額:</translation>
+        <translation type="vanished">總餘額:</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="231"/>
         <source>Unlocked Balance:</source>
-        <translation>可用餘額:</translation>
+        <translation type="vanished">可用餘額:</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="45"/>
+        <source>Balance</source>
+        <translation type="unfinished">餘額</translation>
+    </message>
+    <message>
+        <location filename="../MiddlePanel.qml" line="47"/>
+        <source>Unlocked Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mining</name>
+    <message>
+        <location filename="../pages/Mining.qml" line="72"/>
+        <source>Solo mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="79"/>
+        <source>(only available for local daemons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="85"/>
+        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="86"/>
+        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="87"/>
+        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="88"/>
+        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="89"/>
+        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="99"/>
+        <source>CPU threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="107"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="121"/>
+        <source>Background mining (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="137"/>
+        <source>Enable mining when running on battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="147"/>
+        <source>Manage miner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="156"/>
+        <source>Start mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="166"/>
+        <source>Error starting mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="167"/>
+        <source>Couldn&apos;t start mining.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="169"/>
+        <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="181"/>
+        <source>Stop mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="198"/>
+        <source>Status: not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="209"/>
+        <source>Mining at %1 H/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="212"/>
+        <source>Not mining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Mining.qml" line="214"/>
+        <source>Status: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="52"/>
+        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <source>Synchronizing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="54"/>
         <source>Connected</source>
         <translation>已連接</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="57"/>
         <source>Wrong version</source>
         <translation>版本錯誤</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Disconnected</source>
         <translation>已離線</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="60"/>
         <source>Invalid connection status</source>
         <translation>無效的連接狀態</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="82"/>
+        <location filename="../components/NetworkStatusItem.qml" line="85"/>
         <source>Network status</source>
         <translation>網路同步狀態</translation>
     </message>
@@ -395,17 +649,22 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="68"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
         <source>Please enter wallet password</source>
         <translation>請輸入錢包的密碼</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="143"/>
+        <location filename="../components/PasswordDialog.qml" line="70"/>
+        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="158"/>
+        <location filename="../components/PasswordDialog.qml" line="162"/>
         <source>Ok</source>
         <translation>確定</translation>
     </message>
@@ -413,66 +672,175 @@
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="102"/>
         <source>LOW</source>
-        <translation>低</translation>
+        <translation type="vanished">低</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="113"/>
         <source>MEDIUM</source>
-        <translation>中</translation>
+        <translation type="vanished">中</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="124"/>
         <source>HIGH</source>
-        <translation>高</translation>
+        <translation type="vanished">高</translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProgressBar</name>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="43"/>
+        <source>Establishing connection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="57"/>
+        <source>Blocks remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ProgressBar.qml" line="100"/>
+        <source>Synchronizing blocks</source>
+        <translation type="unfinished">同步區塊中</translation>
     </message>
 </context>
 <context>
     <name>Receive</name>
     <message>
-        <location filename="../pages/Receive.qml" line="56"/>
+        <location filename="../pages/Receive.qml" line="63"/>
         <source>Invalid payment ID</source>
         <translation>無效的付款ID</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="100"/>
+        <source>WARNING: no connection to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="122"/>
+        <source>in the txpool: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="129"/>
+        <source>%2 confirmations: %3 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="131"/>
+        <source>1 confirmation: %2 (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="139"/>
+        <source>No transaction found yet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>Transaction found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="143"/>
+        <source>%1 transactions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="149"/>
+        <source> with more money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="151"/>
+        <source> with not enough money (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="182"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="189"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>唯讀錢包的位址會顯示在這</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="219"/>
+        <source>16 hexadecimal characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="258"/>
         <source>Integrated address</source>
         <translation>整合位址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="267"/>
         <source>ReadOnly wallet integrated address displayed here</source>
         <translation>唯讀錢包的整合位址會顯示在這</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="162"/>
+        <location filename="../pages/Receive.qml" line="320"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="325"/>
+        <source>Tracking payments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="326"/>
+        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="370"/>
+        <source>Save QrCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="371"/>
+        <source>Failed to save QrCode to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="382"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="211"/>
         <source>Payment ID</source>
         <translation>付款ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="170"/>
         <source>16 or 64 hexadecimal characters</source>
-        <translation>16 或 64 十六進位字母</translation>
+        <translation type="vanished">16 或 64 十六進位字母</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="195"/>
+        <location filename="../pages/Receive.qml" line="244"/>
         <source>Generate</source>
         <translation>產生</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="209"/>
-        <location filename="../pages/Receive.qml" line="217"/>
+        <location filename="../pages/Receive.qml" line="291"/>
+        <location filename="../pages/Receive.qml" line="299"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
@@ -516,58 +884,158 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="51"/>
-        <location filename="../pages/Settings.qml" line="110"/>
         <source>Click button to show seed</source>
-        <translation>點選顯示種子碼</translation>
+        <translation type="vanished">點選顯示種子碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="92"/>
         <source>Mnemonic seed: </source>
-        <translation>輔助記憶種子碼:</translation>
+        <translation type="vanished">輔助記憶種子碼:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="139"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>請注意這是唯一需要備份的錢包資訊，請一定要抄寫下來。</translation>
+        <translation type="vanished">請注意這是唯一需要備份的錢包資訊，請一定要抄寫下來。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="152"/>
+        <location filename="../pages/Settings.qml" line="103"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed</source>
         <translation>顯示種子碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="182"/>
+        <location filename="../pages/Settings.qml" line="133"/>
+        <source>Manage daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="150"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="164"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="177"/>
+        <source>Show status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="197"/>
+        <source>Daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="205"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="219"/>
         <source>Daemon address</source>
         <translation>區塊鏈同步程式位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="191"/>
+        <location filename="../pages/Settings.qml" line="228"/>
         <source>Hostname / IP</source>
         <translation>主機名稱 / IP位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="200"/>
+        <location filename="../pages/Settings.qml" line="237"/>
         <source>Port</source>
         <translation>通訊埠</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="212"/>
+        <location filename="../pages/Settings.qml" line="247"/>
+        <source>Login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="265"/>
+        <source>Password</source>
+        <translation type="unfinished">密碼</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="273"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="238"/>
+        <location filename="../pages/Settings.qml" line="300"/>
+        <source>Layout settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="317"/>
+        <source>Custom decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="328"/>
+        <source>Log level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="354"/>
+        <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="370"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="386"/>
+        <source>GUI version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="393"/>
+        <source>Embedded Monero version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="403"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="414"/>
+        <source>Wallet mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="422"/>
+        <source>Error</source>
+        <translation type="unfinished">錯誤</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="423"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>管理錢包</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="251"/>
         <source>Close current wallet and open wizard</source>
-        <translation>關閉當前的錢包然後啟動設定精靈</translation>
+        <translation type="vanished">關閉當前的錢包然後啟動設定精靈</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="262"/>
+        <location filename="../pages/Settings.qml" line="88"/>
         <source>Close wallet</source>
         <translation>關閉錢包</translation>
     </message>
@@ -613,8 +1081,29 @@
     <message>
         <location filename="../pages/Sign.qml" line="167"/>
         <location filename="../pages/Sign.qml" line="242"/>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="208"/>
+        <location filename="../pages/Sign.qml" line="393"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="352"/>
+        <location filename="../pages/Sign.qml" line="426"/>
+        <source>Verify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="444"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SIGN</source>
-        <translation>簽署</translation>
+        <translation type="vanished">簽署</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="183"/>
@@ -623,10 +1112,8 @@
         <translation>或檔案:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="208"/>
-        <location filename="../pages/Sign.qml" line="393"/>
         <source>SELECT</source>
-        <translation>選擇檔案</translation>
+        <translation type="vanished">選擇檔案</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="223"/>
@@ -652,10 +1139,8 @@
         <translation>欲驗證的訊息</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="352"/>
-        <location filename="../pages/Sign.qml" line="426"/>
         <source>VERIFY</source>
-        <translation>驗證</translation>
+        <translation type="vanished">驗證</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="408"/>
@@ -663,20 +1148,19 @@
         <translation>附帶簽署訊息的檔案名稱</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="444"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            簽署的位址 &lt;font size=&apos;2&apos;&gt;  ( 輸入或從簿選擇 &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; 簿選擇 )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            簽署的位址 &lt;font size=&apos;2&apos;&gt;  ( 輸入或從簿選擇 &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; 簿選擇 )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="105"/>
+        <location filename="../components/StandardDialog.qml" line="127"/>
         <source>Ok</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="121"/>
+        <location filename="../components/StandardDialog.qml" line="112"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -684,125 +1168,367 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
         <source>LOW</source>
-        <translation>低</translation>
+        <translation type="vanished">低</translation>
+    </message>
+    <message>
+        <source>MEDIUM</source>
+        <translation type="vanished">中</translation>
+    </message>
+    <message>
+        <source>HIGH</source>
+        <translation type="vanished">高</translation>
+    </message>
+    <message>
+        <location filename="../components/TickDelegate.qml" line="55"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>MEDIUM</source>
-        <translation>中</translation>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="57"/>
-        <source>HIGH</source>
-        <translation>高</translation>
+        <source>High</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="59"/>
+        <location filename="../pages/Transfer.qml" line="66"/>
+        <source>OpenAlias error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="78"/>
+        <source>Privacy level (ringsize %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="125"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="69"/>
+        <location filename="../pages/Transfer.qml" line="135"/>
         <source>Transaction priority</source>
         <translation>交易優先程度</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="91"/>
-        <source></source>
+        <location filename="../pages/Transfer.qml" line="175"/>
+        <source>all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="108"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
+        <source>Low (x1 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
+        <source>Medium (x20 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="195"/>
+        <source>High (x166 fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="223"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="241"/>
+        <source>QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="271"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="289"/>
+        <source>No valid address found at this OpenAlias address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="294"/>
+        <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="296"/>
+        <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="302"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="305"/>
+        <source>No address found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="345"/>
+        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="357"/>
+        <source>Saved to local wallet history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="385"/>
+        <source>Send</source>
+        <translation type="unfinished">付款</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="437"/>
+        <source>Show advanced options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="486"/>
+        <source>Sweep Unmixable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="500"/>
+        <source>create tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="522"/>
+        <source>sign tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="536"/>
+        <source>submit tx file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>Rescan spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="651"/>
+        <source>Error</source>
+        <translation type="unfinished">錯誤</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="561"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="657"/>
+        <source>Information</source>
+        <translation type="unfinished">資訊</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="567"/>
+        <source>Sucessfully rescanned spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="596"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished">
+交易數量: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="605"/>
+        <source>
+Transaction #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="606"/>
+        <source>
+Recipient: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>
+payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="608"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="609"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">手續費: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="610"/>
+        <source>
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="624"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">確認</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="652"/>
+        <source>Can&apos;t submit transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <source>Money sent successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="705"/>
+        <location filename="../pages/Transfer.qml" line="717"/>
+        <source>Wallet is not connected to daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="720"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="725"/>
+        <source>Waiting on daemon synchronization to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="91"/>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
         <source>or ALL</source>
-        <translation>或發送全部餘額</translation>
+        <translation type="vanished">或發送全部餘額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="124"/>
         <source>LOW</source>
-        <translation>低</translation>
+        <translation type="vanished">低</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
         <source>MEDIUM</source>
-        <translation>中</translation>
+        <translation type="vanished">中</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
         <source>HIGH</source>
-        <translation>高</translation>
+        <translation type="vanished">高</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="155"/>
         <source>Privacy level</source>
-        <translation>隱私等級</translation>
+        <translation type="vanished">隱私等級</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="181"/>
+        <location filename="../pages/Transfer.qml" line="465"/>
         <source>Transaction cost</source>
         <translation>交易所需的花費</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    位址 &lt;font size=&apos;2&apos;&gt;  ( 輸入位址或從 &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; 簿選擇 )&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    位址 &lt;font size=&apos;2&apos;&gt;  ( 輸入位址或從 &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; 簿選擇 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="223"/>
+        <location filename="../pages/Transfer.qml" line="320"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>付款ID &lt;font size=&apos;2&apos;&gt;( 可不填 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="235"/>
+        <location filename="../pages/Transfer.qml" line="332"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 或 64 十六進位字元</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="248"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( An optional description that will be saved to the local address book if entered )&lt;/font&gt;</source>
-        <translation>標記 &lt;font size=&apos;2&apos;&gt;( 選填，將儲存在收款位址簿 )&lt;/font&gt;</translation>
+        <translation type="vanished">標記 &lt;font size=&apos;2&apos;&gt;( 選填，將儲存在收款位址簿 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="296"/>
         <source>SEND</source>
-        <translation>付款</translation>
+        <translation type="vanished">付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
         <source>SWEEP UNMIXABLE</source>
-        <translation>去除無法混幣的金額</translation>
+        <translation type="vanished">去除無法混幣的金額</translation>
     </message>
 </context>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
         <source>You can verify that a third party made a payment by supplying:</source>
-        <translation>您可以在此驗證第三方的支付，需提供:</translation>
+        <translation type="vanished">您可以在此驗證第三方的支付，需提供:</translation>
+    </message>
+    <message>
+        <source> - the recipient address,</source>
+        <translation type="vanished"> - 接受方的位址,</translation>
+    </message>
+    <message>
+        <source> - the transaction ID,</source>
+        <translation type="vanished"> - 該項交易的交易ID</translation>
+    </message>
+    <message>
+        <source> - the tx secret key supplied by the sender</source>
+        <translation type="vanished"> - 支付方提供的 tx 金鑰</translation>
+    </message>
+    <message>
+        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
+        <translation type="vanished">如果該支付是同時包含數個交易，每一項交易都必須被確認和合併結果</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="90"/>
+        <source>Verify that a third party made a payment by supplying:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="94"/>
-        <source> - the recipient address,</source>
-        <translation> - 接受方的位址,</translation>
+        <source> - the recipient address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="98"/>
-        <source> - the transaction ID,</source>
-        <translation> - 該項交易的交易ID</translation>
+        <source> - the transaction ID</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="102"/>
-        <source> - the tx secret key supplied by the sender</source>
-        <translation> - 支付方提供的 tx 金鑰</translation>
+        <source> - the secret transaction key supplied by the sender</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="106"/>
-        <source>If a payment was made up of several transactions, each transaction must be checked, and the results added</source>
-        <translation>如果該支付是同時包含數個交易，每一項交易都必須被確認和合併結果</translation>
+        <source>If a payment had several transactions then each must be checked and the results combined.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="119"/>
@@ -821,8 +1547,22 @@
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="157"/>
+        <source>Paste tx ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="189"/>
+        <source>Paste tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="212"/>
+        <source>Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transaction ID here</source>
-        <translation>輸入交易ID</translation>
+        <translation type="vanished">輸入交易ID</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="181"/>
@@ -830,14 +1570,12 @@
         <translation>交易金鑰</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="189"/>
         <source>Transaction key here</source>
-        <translation>輸入交易金鑰</translation>
+        <translation type="vanished">輸入交易金鑰</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="213"/>
         <source>CHECK</source>
-        <translation>檢查</translation>
+        <translation type="vanished">檢查</translation>
     </message>
 </context>
 <context>
@@ -853,42 +1591,57 @@
         <translation>開始同步 Monero 區塊鏈?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="115"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>這是唯一需要備份的錢包資訊，請一定要抄寫下來。你將會在下一個步驟被要求確認這份種子碼以確保你有妥善備份它。</translation>
+        <translation type="vanished">這是唯一需要備份的錢包資訊，請一定要抄寫下來。你將會在下一個步驟被要求確認這份種子碼以確保你有妥善備份它。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="127"/>
+        <location filename="../wizard/WizardConfigure.qml" line="115"/>
+        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
+        <translation type="unfinished">請注意這是唯一需要備份的錢包資訊，請一定要抄寫下來。</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardConfigure.qml" line="126"/>
         <source>Enable disk conservation mode?</source>
         <translation>啟動硬碟節約模式?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="145"/>
+        <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
         <translation>硬碟節約模式能精簡區塊鏈的資料而減少硬碟空間的使用量，但保存完整的區塊鏈能加強 Monero 網路的安全性，當您需要在容量較小的硬碟上執行，那麼這個功能就很適合您，此功能對於網路頻寬的用量沒有影響。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="158"/>
+        <location filename="../wizard/WizardConfigure.qml" line="157"/>
         <source>Allow background mining?</source>
         <translation>允許程式在背景挖礦嗎?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="176"/>
+        <location filename="../wizard/WizardConfigure.qml" line="175"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>啟動挖礦功能可讓 Monero 的系統網路更加安全，且在工作完成時獲得小額的獎勵金。這個功能只會在電腦插著電源並且閒置時才會自動啟動，當您繼續使用電腦後即會停止挖礦。</translation>
     </message>
 </context>
 <context>
+    <name>WizardCreateViewOnlyWallet</name>
+    <message>
+        <location filename="../wizard/WizardCreateViewOnlyWallet.qml" line="68"/>
+        <source>Create view only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardCreateWallet</name>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="94"/>
         <source>A new wallet has been created for you</source>
-        <translation>已為您建立一個新的錢包</translation>
+        <translation type="vanished">已為您建立一個新的錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateWallet.qml" line="95"/>
         <source>This is the 25 word mnemonic for your wallet</source>
-        <translation>這是錢包的25字輔助記憶種子碼</translation>
+        <translation type="vanished">這是錢包的25字輔助記憶種子碼</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateWallet.qml" line="99"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -927,97 +1680,182 @@
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Enabled</source>
         <translation>啟用</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="45"/>
-        <location filename="../wizard/WizardFinish.qml" line="48"/>
-        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="49"/>
+        <location filename="../wizard/WizardFinish.qml" line="52"/>
+        <location filename="../wizard/WizardFinish.qml" line="54"/>
         <source>Disabled</source>
         <translation>停用</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="58"/>
         <source>Language</source>
         <translation>語言</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Account name</source>
-        <translation>帳戶名稱</translation>
+        <translation type="vanished">帳戶名稱</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="56"/>
         <source>Seed</source>
-        <translation>種子碼</translation>
+        <translation type="vanished">種子碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="57"/>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <source>Backup seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
         <translation>錢包位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="63"/>
+        <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
         <translation>區塊鏈同步程式位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="64"/>
+        <location filename="../wizard/WizardFinish.qml" line="68"/>
         <source>Testnet</source>
         <translation>連接到測試用網路</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="66"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Restore height</source>
         <translation>指定區塊高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="73"/>
-        <source>An overview of your Monero configuration is below:</source>
-        <translation>以下是您的 Monero 錢包設定總覽:</translation>
+        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <source>New wallet details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
+        <source>You’re all set up!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An overview of your Monero configuration is below:</source>
+        <translation type="vanished">以下是您的 Monero 錢包設定總覽:</translation>
+    </message>
+    <message>
         <source>You’re all setup!</source>
-        <translation>您已完成所有設定!</translation>
+        <translation type="vanished">您已完成所有設定!</translation>
     </message>
 </context>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="202"/>
+        <location filename="../wizard/WizardMain.qml" line="168"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>已有重複的錢包名稱存在，請更改錢包名稱</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="337"/>
+        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <source>Non-ASCII characters are not allowed in wallet path or account name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="350"/>
         <source>USE MONERO</source>
         <translation>使用 MONERO</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
+        <source>Create wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="377"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="378"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
+        <source>Error</source>
+        <translation type="unfinished">錯誤</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMain.qml" line="399"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="107"/>
         <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation>這是您的錢包名稱，您也可以自己更改成想要的名稱:</translation>
+        <translation type="vanished">這是您的錢包名稱，您也可以自己更改成想要的名稱:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore height</source>
-        <translation>回復區塊高度</translation>
+        <translation type="vanished">回復區塊高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="197"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <source>Wallet name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <source>Restore from seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <source>Restore from keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Your wallet is stored in</source>
         <translation>您的錢包被儲存在</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="209"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="272"/>
         <source>Please choose a directory</source>
         <translation>請選擇一個目錄</translation>
     </message>
@@ -1025,45 +1863,70 @@
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="76"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation>這是您唯一需要備份的錢包資訊，請一定要抄寫下來。您將會在下一個後被要求確認這份種子碼以確保你有妥善備份它。</translation>
+        <translation type="vanished">這是您唯一需要備份的錢包資訊，請一定要抄寫下來。您將會在下一個後被要求確認這份種子碼以確保你有妥善備份它。</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
+        <source>Enter your 25 word mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="79"/>
+        <location filename="../wizard/WizardOptions.qml" line="87"/>
         <source>Welcome to Monero!</source>
         <translation>歡迎使用 Monero！</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="91"/>
+        <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
         <translation>請於下面選擇您需要的功能:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="140"/>
+        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <source>Restore wallet from keys or mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <source>Open a wallet from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="262"/>
+        <source>Custom daemon address (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This is my first time, I want to create a new account</source>
-        <translation>這是我第一次使用，我想要創建一個新的帳戶</translation>
+        <translation type="vanished">這是我第一次使用，我想要創建一個新的帳戶</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="177"/>
         <source>I want to recover my account from my 25 word seed</source>
-        <translation>我想要從一組25字種子碼回復我的帳戶</translation>
+        <translation type="vanished">我想要從一組25字種子碼回復我的帳戶</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="216"/>
         <source>I want to open a wallet from file</source>
-        <translation>我想要從檔案開啟錢包</translation>
+        <translation type="vanished">我想要從檔案開啟錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="251"/>
         <source>Please setup daemon address below.</source>
-        <translation>請在下面設定區塊鏈同步程式的位置。</translation>
+        <translation type="vanished">請在下面設定區塊鏈同步程式的位置。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="271"/>
+        <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>連接至測試用網路</translation>
     </message>
@@ -1071,55 +1934,82 @@
 <context>
     <name>WizardPassword</name>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="52"/>
         <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation>您的新錢包已被建立，請為它設定一組密碼</translation>
+        <translation type="vanished">您的新錢包已被建立，請為它設定一組密碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="54"/>
         <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation>您的錢包已被成功回復，請為它設定一組密碼</translation>
+        <translation type="vanished">您的錢包已被成功回復，請為它設定一組密碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="138"/>
         <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
                         Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation>請注意:這個密碼無法被回復，如果忘記了這組密碼，您將需要用剛剛獲得的輔助記憶種子碼重新回復您的錢包&lt;br/&gt;&lt;br/&gt;
+        <translation type="vanished">請注意:這個密碼無法被回復，如果忘記了這組密碼，您將需要用剛剛獲得的輔助記憶種子碼重新回復您的錢包&lt;br/&gt;&lt;br/&gt;
                         密碼將會用來保護您的錢包或確認重要的動作，所以請確認您的密碼強度足夠安全。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="152"/>
         <source>Password</source>
-        <translation>密碼</translation>
+        <translation type="vanished">密碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="165"/>
         <source>Confirm password</source>
-        <translation>確認密碼</translation>
+        <translation type="vanished">確認密碼</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="57"/>
+        <location filename="../wizard/WizardPassword.qml" line="59"/>
+        <source>Give your wallet a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
+                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardPasswordUI</name>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <source>Password</source>
+        <translation type="unfinished">密碼</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <source>Confirm password</source>
+        <translation type="unfinished">確認密碼</translation>
     </message>
 </context>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="87"/>
         <source>We&apos;re ready to recover your account</source>
-        <translation>已準備好回復您的錢包</translation>
+        <translation type="vanished">已準備好回復您的錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="88"/>
         <source>Please enter your 25 word private key</source>
-        <translation>請輸入您的 25字種子碼</translation>
+        <translation type="vanished">請輸入您的 25字種子碼</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <source>Restore wallet</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="85"/>
         <source>Welcome</source>
-        <translation>歡迎</translation>
+        <translation type="vanished">歡迎</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="99"/>
+        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <source>Welcome to Monero!</source>
+        <translation type="unfinished">歡迎使用 Monero！</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
         <translation>請選擇您的語言和地區格式。</translation>
     </message>
@@ -1127,77 +2017,111 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="248"/>
-        <location filename="../main.qml" line="369"/>
-        <location filename="../main.qml" line="430"/>
-        <location filename="../main.qml" line="441"/>
-        <location filename="../main.qml" line="465"/>
-        <location filename="../main.qml" line="512"/>
-        <location filename="../main.qml" line="546"/>
-        <location filename="../main.qml" line="575"/>
+        <location filename="../main.qml" line="311"/>
+        <location filename="../main.qml" line="476"/>
+        <location filename="../main.qml" line="537"/>
+        <location filename="../main.qml" line="548"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="651"/>
+        <location filename="../main.qml" line="689"/>
+        <location filename="../main.qml" line="719"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="249"/>
+        <location filename="../main.qml" line="312"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>無法開啟這個錢包:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="336"/>
         <source>Synchronizing blocks %1 / %2</source>
-        <translation>同步區塊中 %1 / %2</translation>
+        <translation type="vanished">同步區塊中 %1 / %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="371"/>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (waiting for block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance (~%1 min)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="343"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished">總餘額</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="395"/>
+        <source>Waiting for daemon to start...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="401"/>
+        <source>Waiting for daemon to stop...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <source>Daemon failed to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="427"/>
+        <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="478"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>無法建立此項交易: 區塊鏈同步程式版本錯誤:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="373"/>
-        <location filename="../main.qml" line="466"/>
+        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="591"/>
         <source>Can&apos;t create transaction: </source>
         <translation>無法建立此項交易:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="381"/>
-        <location filename="../main.qml" line="382"/>
-        <location filename="../main.qml" line="474"/>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="599"/>
+        <location filename="../main.qml" line="600"/>
         <source>No unmixable outputs to sweep</source>
         <translation>沒有無法混幣的輸出需要去除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
-        <location filename="../main.qml" line="487"/>
+        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="612"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="395"/>
-        <location filename="../main.qml" line="488"/>
+        <location filename="../main.qml" line="502"/>
+        <location filename="../main.qml" line="613"/>
         <source>Please confirm transaction:
 </source>
         <translation>請確認此項交易:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="396"/>
+        <location filename="../main.qml" line="503"/>
         <source>
 Address: </source>
         <translation>
 位址: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="397"/>
+        <location filename="../main.qml" line="504"/>
         <source>
 Payment ID: </source>
         <translation>
 付款ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="398"/>
-        <location filename="../main.qml" line="489"/>
+        <location filename="../main.qml" line="505"/>
+        <location filename="../main.qml" line="614"/>
         <source>
 
 Amount: </source>
@@ -1206,30 +2130,61 @@ Amount: </source>
 金額: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="399"/>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="615"/>
         <source>
 Fee: </source>
         <translation>手續費: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="400"/>
+        <location filename="../main.qml" line="507"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="711"/>
+        <source>This address received %1 monero, with %2 confirmation(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1270"/>
+        <source>Daemon is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1271"/>
+        <source>Daemon will still be running in background when GUI is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1273"/>
+        <source>Stop daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1308"/>
+        <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>
 
 Mixin: </source>
-        <translation>
+        <translation type="vanished">
 
 混幣數量: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="401"/>
+        <location filename="../main.qml" line="508"/>
         <source>
 Number of transactions: </source>
         <translation>
 交易數量: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="402"/>
+        <location filename="../main.qml" line="509"/>
         <source>
 
 Description: </source>
@@ -1238,67 +2193,81 @@ Description: </source>
 描述: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="431"/>
+        <location filename="../main.qml" line="538"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>金額錯誤: 數字需介於 %1 到 %2 之間</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="442"/>
+        <location filename="../main.qml" line="549"/>
         <source>insufficient funds. Unlocked balance: %1</source>
         <translation>資金不足，總餘額僅有: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="513"/>
+        <location filename="../main.qml" line="652"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>無法付款: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
+        <location filename="../main.qml" line="655"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="661"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation> %1 筆款項已成功發送</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="661"/>
+        <source>Transaction saved to file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="701"/>
         <source>Payment check</source>
         <translation>付款確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="562"/>
+        <location filename="../main.qml" line="706"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>這個位址已收到 %1 monero幣，但這筆交易尚未被礦工確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="567"/>
         <source>This address received %1 monero, with %2 confirmations</source>
-        <translation>這個位址已收到 %1 monero幣，並已經過 %2 次的確認</translation>
+        <translation type="vanished">這個位址已收到 %1 monero幣，並已經過 %2 次的確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="571"/>
+        <location filename="../main.qml" line="715"/>
         <source>This address received nothing</source>
         <translation>這個位址沒有收到款項</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="731"/>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance (syncing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="727"/>
+        <source>Balance</source>
+        <translation type="unfinished">餘額</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="933"/>
         <source>Please wait...</source>
         <translation>請稍後...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="756"/>
+        <location filename="../main.qml" line="962"/>
         <source>Program setup wizard</source>
         <translation>程式設定精靈</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="770"/>
+        <location filename="../main.qml" line="977"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="1018"/>
         <source>send to the same destination</source>
         <translation>付款至相同位址</translation>
     </message>


### PR DESCRIPTION
Fixes missing translations from LeftPanel.qml and MiddlePanel.qml. More missing translations needed to some files.
Updated the translation files with `lupdate -verbose monero-wallet-gui.pro` (the [log](https://paste.fedoraproject.org/paste/F3w4CBiNDIuzCccVZv5lKl5M1UNdIGYhyRLivL9gydE=))
Also updated the dutch translation.