### PR TITLE
Remove default payment ID from receive page

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -51,16 +51,22 @@ Rectangle {
     function updatePaymentId(payment_id) {
         if (typeof appWindow.currentWallet === 'undefined' || appWindow.currentWallet == null)
             return
+
         // generate a new one if not given as argument
         if (typeof payment_id === 'undefined') {
             payment_id = appWindow.currentWallet.generatePaymentId()
-            appWindow.persistentSettings.payment_id = payment_id
             paymentIdLine.text = payment_id
         }
-        addressLine.text = appWindow.currentWallet.address
-        integratedAddressLine.text = appWindow.currentWallet.integratedAddress(payment_id)
-        if (integratedAddressLine.text === "")
-          integratedAddressLine.text = qsTr("Invalid payment ID")
+
+        if (payment_id.length > 0) {
+            integratedAddressLine.text = appWindow.currentWallet.integratedAddress(payment_id)
+            if (integratedAddressLine.text === "")
+              integratedAddressLine.text = qsTr("Invalid payment ID")
+        }
+        else {
+            integratedAddressLine.text = ""
+        }
+
         update()
     }
 
@@ -243,13 +249,10 @@ Rectangle {
                 pressedColor: "#FF4304"
                 text: qsTr("Generate") + translationManager.emptyString;
                 anchors.right: parent.right
-                onClicked: {
-                    appWindow.persistentSettings.payment_id = appWindow.currentWallet.generatePaymentId();
-                    updatePaymentId()
-                }
+                onClicked: updatePaymentId()
             }
         }
-        
+
         RowLayout {
             id: integratedAddressRow
             Label {
@@ -414,12 +417,14 @@ Rectangle {
     function onPageCompleted() {
         console.log("Receive page loaded");
 
-        if(addressLine.text.length === 0 || addressLine.text !== appWindow.currentWallet.address) {
-            updatePaymentId()
+        if (appWindow.currentWallet) {
+            if (addressLine.text.length === 0 || addressLine.text !== appWindow.currentWallet.address) {
+                addressLine.text = appWindow.currentWallet.address
+            }
         }
+
         update()
         timer.running = true
-
     }
 
     function onPageClosed() {

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -64,6 +64,7 @@ Rectangle {
               integratedAddressLine.text = qsTr("Invalid payment ID")
         }
         else {
+            paymentIdLine.text = ""
             integratedAddressLine.text = ""
         }
 
@@ -248,8 +249,19 @@ Rectangle {
                 releasedColor: "#FF6C3C"
                 pressedColor: "#FF4304"
                 text: qsTr("Generate") + translationManager.emptyString;
-                anchors.right: parent.right
                 onClicked: updatePaymentId()
+            }
+
+            StandardButton {
+                id: clearPaymentId
+                enabled: !!paymentIdLine.text
+                width: 80
+                shadowReleasedColor: "#FF4304"
+                shadowPressedColor: "#B32D00"
+                releasedColor: "#FF6C3C"
+                pressedColor: "#FF4304"
+                text: qsTr("Clear") + translationManager.emptyString;
+                onClicked: updatePaymentId("")
             }
         }
 


### PR DESCRIPTION
These changes were requested in #254. This removes the default payment ID value from the receive page. I also added a "clear" button next to the payment ID generate button. Let me know if the button commit should go in its own PR. I'm not familiar with how you guys manage this repo.

Also, I added a new button string which needs translation entries. Are the files updated by hand or with a script?
