### PR TITLE
Better spacing for Wizard password warning

### DIFF
--- a/wizard/WizardPassword.qml
+++ b/wizard/WizardPassword.qml
@@ -124,7 +124,7 @@ ColumnLayout {
             //renderType: Text.NativeRendering
             color: "#4A4646"
             horizontalAlignment: Text.AlignHCenter
-            text: qsTr("Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.<br/><br/>
+            text: qsTr(" <br>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.<br/><br/>
                         <b>Enter a strong password</b> (using letters, numbers, and/or symbols):")
                     + translationManager.emptyString
         }


### PR DESCRIPTION
Title was vertically next to "Note:" warning. Now all the lines have (mostly) equal vertical spacing, though at some point it might be good to switch the `<br>` code with a more accurate margin.

![screen shot 2017-03-19 at 1 33 39 pm](https://cloud.githubusercontent.com/assets/21302237/24083165/e3628262-0ca8-11e7-8057-fb410f17dc29.png)
