### PR TITLE
Remove negative letter spacing

### DIFF
--- a/BasicPanel.qml
+++ b/BasicPanel.qml
@@ -140,7 +140,6 @@ Rectangle {
                 height: 20
                 font.family: "Arial"
                 font.pixelSize: 14
-                font.letterSpacing: -1
                 elide: Text.ElideRight
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignBottom

--- a/BasicPanel.qml
+++ b/BasicPanel.qml
@@ -90,7 +90,6 @@ Rectangle {
                 height: 20
                 font.family: "Arial"
                 font.pixelSize: 12
-                font.letterSpacing: -1
                 elide: Text.ElideRight
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignBottom
@@ -104,7 +103,6 @@ Rectangle {
                 height: 20
                 font.family: "Arial"
                 font.pixelSize: 18
-                font.letterSpacing: -1
                 elide: Text.ElideRight
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignBottom

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -206,7 +206,6 @@ Rectangle {
                     height: 20
                     font.family: "Arial"
                     font.pixelSize: 12
-                    font.letterSpacing: -1
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignBottom
@@ -220,7 +219,6 @@ Rectangle {
                     height: 20
                     font.family: "Arial"
                     font.pixelSize: 18
-                    font.letterSpacing: -1
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignBottom
@@ -245,7 +243,6 @@ Rectangle {
                     height: 20
                     font.family: "Arial"
                     font.pixelSize: 12
-                    font.letterSpacing: -1
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignBottom
@@ -259,7 +256,6 @@ Rectangle {
                     height: 20
                     font.family: "Arial"
                     font.pixelSize: 14
-                    font.letterSpacing: -1
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignBottom

--- a/components/AddressBookTable.qml
+++ b/components/AddressBookTable.qml
@@ -87,7 +87,6 @@ ListView {
             anchors.rightMargin: 40
             font.family: "Arial"
             font.pixelSize: 16
-            font.letterSpacing: -1
             color: "#545454"
             text: address
         }
@@ -101,7 +100,6 @@ ListView {
             width: 139
             font.family: "Arial"
             font.pixelSize: 12
-            font.letterSpacing: -1
             color: "#535353"
             text: qsTr("Payment ID:") + translationManager.emptyString
         }
@@ -117,7 +115,6 @@ ListView {
 
             font.family: "Arial"
             font.pixelSize: 13
-            font.letterSpacing: -1
             color: "#545454"
             text: paymentId
         }

--- a/components/CheckBox.qml
+++ b/components/CheckBox.qml
@@ -76,7 +76,6 @@ Item {
         anchors.leftMargin: 25 + 12
         font.family: "Arial"
         font.pixelSize: checkBox.fontSize
-        font.letterSpacing: -1
         color: "#525252"
     }
 

--- a/components/DashboardTable.qml
+++ b/components/DashboardTable.qml
@@ -145,7 +145,6 @@ ListView {
                     Text {
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: "#000000"
                         text: date
                     }
@@ -153,7 +152,6 @@ ListView {
                     Text {
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: "#000000"
                         text: time
                     }
@@ -175,7 +173,6 @@ ListView {
                 Text {
                     font.family: "Arial"
                     font.pixelSize: 18
-                    font.letterSpacing: -1
                     color: "#000000"
                     text: balance
                 }
@@ -208,7 +205,6 @@ ListView {
                         anchors.bottom: parent.bottom
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: out ? "#FF4F41" : "#36B05B"
                         text: amount
                     }

--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -285,7 +285,6 @@ Item {
                         anchors.centerIn: parent
                         font.family: "Arial"
                         font.pixelSize: 12
-                        font.letterSpacing: -1
                         font.bold: dayArea.pressed
                         text: styleData.date.getDate()
                         color: {
@@ -322,7 +321,6 @@ Item {
                         elide: Text.ElideRight
                         font.family: "Arial"
                         font.pixelSize: 9
-                        font.letterSpacing: -1
                         color: "#535353"
                         text: {
                             var locale = Qt.locale()
@@ -339,7 +337,6 @@ Item {
                         anchors.centerIn: parent
                         font.family: "Arial"
                         font.pixelSize: 12
-                        font.letterSpacing: -1
                         color: "#4A4646"
                         text: styleData.title
                     }

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -226,7 +226,6 @@ ListView {
                 //elide: Text.ElideRight
                 font.family: "Arial"
                 font.pixelSize:13
-                font.letterSpacing: -1
                 color: "#545454"
                 text: "(" + lookupPaymentID(paymentId) + ")"
                 visible: text !== "()"
@@ -309,7 +308,6 @@ ListView {
                     Text {
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: "#000000"
                         text: date
                     }
@@ -317,7 +315,6 @@ ListView {
                     Text {
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: "#000000"
                         text: time
                     }
@@ -342,7 +339,6 @@ ListView {
                 Text {
                     font.family: "Arial"
                     font.pixelSize: 18
-                    font.letterSpacing: -1
                     color: "#000000"
                     text: balance
                 }
@@ -377,7 +373,6 @@ ListView {
                         anchors.bottom: parent.bottom
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: isOut ? "#FF4F41" : "#36B05B"
                         text:  displayAmount
                     }
@@ -403,7 +398,6 @@ ListView {
                         anchors.bottom: parent.bottom
                         font.family: "Arial"
                         font.pixelSize: 18
-                        font.letterSpacing: -1
                         color: "#FF4F41"
                         text:  fee
                     }

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -199,7 +199,6 @@ ListView {
                 anchors.bottom: parent.bottom
                 font.family: "Arial"
                 font.pixelSize: 12
-                font.letterSpacing: -1
                 color: "#535353"
                 text: paymentId !== "" ? qsTr("Payment ID:")  + translationManager.emptyString : ""
             }
@@ -213,7 +212,6 @@ ListView {
                 //elide: Text.ElideRight
                 font.family: "Arial"
                 font.pixelSize:13
-                font.letterSpacing: -1
                 color: "#545454"
                 text: paymentId
 
@@ -250,7 +248,6 @@ ListView {
                 width: 86
                 font.family: "Arial"
                 font.pixelSize: 12
-                font.letterSpacing: -1
                 color: "#535353"
                 text:  qsTr("BlockHeight:")  + translationManager.emptyString
             }

--- a/components/SearchInput.qml
+++ b/components/SearchInput.qml
@@ -100,7 +100,6 @@ Item {
                     font.family: "Arial"
                     font.pixelSize: 12
                     font.bold: true
-                    font.letterSpacing: -1
                     color: "#4A4747"
                     text: "NAME"
                 }
@@ -195,7 +194,6 @@ Item {
                             anchors.rightMargin: 12
                             font.family: "Arial"
                             font.bold: true
-                            font.letterSpacing: -1
                             font.pixelSize: 12
                             color: delegateArea.pressed || parent.isCurrent ? "#FFFFFF" : "#4A4646"
                             text: name

--- a/components/TipItem.qml
+++ b/components/TipItem.qml
@@ -65,7 +65,6 @@ Window {
             lineHeight: 0.7
             font.family: "Arial"
             font.pixelSize: 12
-            font.letterSpacing: -1
             color: "#FFFFFF"
         }
     }

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -47,7 +47,6 @@ Rectangle {
         anchors.centerIn: parent
         font.family: "Arial"
         font.pixelSize: 15
-        font.letterSpacing: -1
         color: "#FFFFFF"
         text: titleBar.title
         visible: customDecorations

--- a/main.qml
+++ b/main.qml
@@ -1253,7 +1253,6 @@ ApplicationWindow {
                 lineHeight: 0.7
                 font.family: "Arial"
                 font.pixelSize: 12
-                font.letterSpacing: -1
                 color: "#FFFFFF"
             }
         }


### PR DESCRIPTION
The GUI currently is inconsistent with it's application of negative letter space, and I'm unsure why this styling was chosen. It seems only to only contribute illegibility. Whatever the case, some words currently utilize it and some do not, an inconsistently that leads to a more distracting and confusing design overall. Current state:

![negativeletterspace](https://cloud.githubusercontent.com/assets/21302237/24083481/d955563c-0cad-11e7-9ea9-a8a8b78d3ce0.png)

This PR removes negative letter spacing, making things look much better. Corrected state:

![screen shot 2017-03-19 at 1 51 20 pm](https://cloud.githubusercontent.com/assets/21302237/24083485/de01263e-0cad-11e7-9c95-813d8d57f475.png)

If we decide to reapply negative letter spacing at some point in the future, it'll be easier, since we can choose which elements can consistently have it, and which don't need it.