### PR TITLE
Rename title of Readme.md to Monero Core (GUI) - No merge yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monero is a private, secure, untraceable, decentralised digital currency. You ar
 
 ## About this Project
 
-This is the GUI for the [core Monero implementation](https://github.com/monero-project/monero). It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.
+This is the repository for Monero Core (GUI). It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.
 
 As with many development projects, the repository on Github is considered to be the "staging" area for the latest changes. Before changes are merged into that branch on the main repository, they are tested by individual developers in their own branches, submitted as a pull request, and then subsequently tested by contributors who focus on testing and code reviews. That having been said, the repository should be carefully considered before using it in a production environment, unless there is a patch in the repository for a particular show-stopping issue you are experiencing. It is generally a better idea to use a tagged release for stability.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Monero GUI
+# Monero Core (GUI)
 
 Copyright (c) 2014-2017, The Monero Project
 


### PR DESCRIPTION
Right now, we have a disconnection that is happening. The repo is called monero-core while the title on the readme calls it Monero GUI. I think originally it was also named Monero Core, but was changed to Monero GUI because it was confusing people looking for the GUI.

This PR proposes to rename the Readme back to Monero Core, but to include (GUI) in parentheses. It's still a good idea to keep calling the repo Core, since this will be the core software that the majority of users will use. And it's good to bring the Readme title back in line with the repo name, ie Monero Core. But including GUI in parenthesis will help people looking for the GUI who were previously confused, which solves the reason for the original change.