### PR TITLE
Simplify fee structure (divide all by 4)

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -199,10 +199,10 @@ Rectangle {
       ListModel {
            id: priorityModelV5
 
-           ListElement { column1: qsTr("Low (x0.25 fee)") ; column2: ""; priority: 1}
+           ListElement { column1: qsTr("Slow (x0.25 fee)") ; column2: ""; priority: 1}
            ListElement { column1: qsTr("Default (x1 fee)") ; column2: ""; priority: 2 }
-           ListElement { column1: qsTr("Medium (x5 fee)") ; column2: ""; priority: 3 }
-           ListElement { column1: qsTr("High (x41.5 fee)")  ; column2: "";  priority: 4 }
+           ListElement { column1: qsTr("Fast (x5 fee)") ; column2: ""; priority: 3 }
+           ListElement { column1: qsTr("Fastest (x41.5 fee)")  ; column2: "";  priority: 4 }
 
        }
 

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -199,10 +199,10 @@ Rectangle {
       ListModel {
            id: priorityModelV5
 
-           ListElement { column1: qsTr("Low (x1 fee)") ; column2: ""; priority: 1}
-           ListElement { column1: qsTr("Default (x4 fee)") ; column2: ""; priority: 2 }
-           ListElement { column1: qsTr("Medium (x20 fee)") ; column2: ""; priority: 3 }
-           ListElement { column1: qsTr("High (x166 fee)")  ; column2: "";  priority: 4 }
+           ListElement { column1: qsTr("Low (x0.25 fee)") ; column2: ""; priority: 1}
+           ListElement { column1: qsTr("Default (x1 fee)") ; column2: ""; priority: 2 }
+           ListElement { column1: qsTr("Medium (x5 fee)") ; column2: ""; priority: 3 }
+           ListElement { column1: qsTr("High (x41.5 fee)")  ; column2: "";  priority: 4 }
 
        }
 


### PR DESCRIPTION
Right now the fees are structured Low (x1 fee), Default (x4 fee), Medium (x20 fee), and High (x166 fee). But this makes it look like the default fee is paying four times the regular fee (or, default is paying 4x the default), which is confusing.

This PR suggest lowering all fee multipliers by a factor of four. So Default is now just x1 fee. Low is x0.25 fee, Medium is x5 fee, and High is x41.5.