### PR TITLE
Address Book context menu : Send to this address

### DIFF
--- a/components/AddressBookTable.qml
+++ b/components/AddressBookTable.qml
@@ -122,7 +122,7 @@ ListView {
         ListModel {
             id: dropModel
             ListElement { name: "<b>Copy address to clipboard</b>"; icon: "../images/dropdownCopy.png" }
-            ListElement { name: "<b>Send to same destination</b>"; icon: "../images/dropdownSend.png" }
+            ListElement { name: "<b>Send to this address</b>"; icon: "../images/dropdownSend.png" }
 //            ListElement { name: "<b>Find similar transactions</b>"; icon: "../images/dropdownSearch.png" }
             ListElement { name: "<b>Remove from address book</b>"; icon: "../images/dropdownDel.png" }
         }

--- a/components/DashboardTable.qml
+++ b/components/DashboardTable.qml
@@ -216,7 +216,7 @@ ListView {
             id: dropModel
             ListElement { name: "<b>Copy address to clipboard</b>"; icon: "../images/dropdownCopy.png" }
             ListElement { name: "<b>Add to address book</b>"; icon: "../images/dropdownAdd.png" }
-            ListElement { name: "<b>Send to same destination</b>"; icon: "../images/dropdownSend.png" }
+            ListElement { name: "<b>Send to this address</b>"; icon: "../images/dropdownSend.png" }
             ListElement { name: "<b>Find similar transactions</b>"; icon: "../images/dropdownSearch.png" }
         }
 

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -443,7 +443,7 @@ ListView {
         id: dropModel
         ListElement { name: "<b>Copy address to clipboard</b>"; icon: "../images/dropdownCopy.png" }
         ListElement { name: "<b>Add to address book</b>"; icon: "../images/dropdownAdd.png" }
-        ListElement { name: "<b>Send to same destination</b>"; icon: "../images/dropdownSend.png" }
+        ListElement { name: "<b>Send to this address</b>"; icon: "../images/dropdownSend.png" }
         ListElement { name: "<b>Find similar transactions</b>"; icon: "../images/dropdownSearch.png" }
     }
 

--- a/components/TableDropdown.qml
+++ b/components/TableDropdown.qml
@@ -180,7 +180,7 @@ Item {
 
                     // Workaround for translations in listElements. All translated strings needs to be listed in this file.
                     property string stringCopy: qsTr("<b>Copy address to clipboard</b>") + translationManager.emptyString
-                    property string stringSend: qsTr("<b>Send to same destination</b>") + translationManager.emptyString
+                    property string stringSend: qsTr("<b>Send to this address</b>") + translationManager.emptyString
                     property string stringFind: qsTr("<b>Find similar transactions</b>") + translationManager.emptyString
                     property string stringRemove: qsTr("<b>Remove from address book</b>") + translationManager.emptyString
 


### PR DESCRIPTION
This is a small improvement to the context menu which is shown for each entry in the `AddressBookTable`.  Currently, there is an option "**Send to same destination**" which is unclear as it suggests some vague notion that the user has already sent XMR to this destination and would like to do so again.

This PR replaces the above message with "**Send to this address**", as the currently selected address will be inserted into the Send view as the recipient address.

Screenshot:
![monero-send-to-this-address](https://cloud.githubusercontent.com/assets/5115470/25141967/9b1ae498-2465-11e7-8b2b-35da45313abf.png)

I found several other instances of this string and updated all for consistency.

Changes / suggestions welcome.