### PR TITLE
Add tip text to labels

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -128,7 +128,7 @@ Rectangle {
             text: qsTr("Balance") + translationManager.emptyString
             anchors.left: parent.left
             anchors.leftMargin: 50
-            tipText: qsTr("Test tip 1<br/><br/>line 2") + translationManager.emptyString
+            tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.") + translationManager.emptyString
         }
 
         Row {
@@ -172,7 +172,7 @@ Rectangle {
             text: qsTr("Unlocked balance") + translationManager.emptyString
             anchors.left: parent.left
             anchors.leftMargin: 50
-            tipText: qsTr("Test tip 2<br/><br/>line 2") + translationManager.emptyString
+            tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
         }
 
         Text {

--- a/components/Label.qml
+++ b/components/Label.qml
@@ -56,26 +56,27 @@ Item {
         anchors.left: label.right
         anchors.leftMargin: 5
         source: "../images/whatIsIcon.png"
-        visible: appWindow.whatIsEnable
+        visible: appWindow.whatIsEnable && item.tipText != ""
     }
 
     MouseArea {
         anchors.fill: icon
-        enabled: appWindow.whatIsEnable
+        enabled: appWindow.whatIsEnable && icon.visible
         hoverEnabled: true
         onEntered: {
-            icon.visible = false
-            var pos = appWindow.mapFromItem(icon, 0, -15)
-            tipItem.text = item.tipText
-            tipItem.x = pos.x
-            if(tipItem.height > 30)
-                pos.y -= tipItem.height - 28
-            tipItem.y = pos.y
-            tipItem.visible = true
+            var pos = rootItem.mapFromItem(icon, 20, -35)
+            appWindow.toolTip.text = item.tipText
+            appWindow.toolTip.x = pos.x - appWindow.toolTip.width/2
+            appWindow.toolTip.tipX = appWindow.toolTip.width/2 - 10;
+            if(appWindow.toolTip.height > 30)
+                pos.y -= appWindow.toolTip.height - 30
+            appWindow.toolTip.y = pos.y
+            appWindow.toolTip.visible = true
+            appWindow.toolTip.z = 3
+
         }
         onExited: {
-            icon.visible = Qt.binding(function(){ return appWindow.whatIsEnable; })
-            tipItem.visible = false
+            appWindow.toolTip.visible = false
         }
     }
 }

--- a/components/TableDropdown.qml
+++ b/components/TableDropdown.qml
@@ -220,8 +220,7 @@ Item {
                                 var pos = rootItem.mapFromItem(delegate, 30, -25)
                                 appWindow.toolTip.text = qsTr(name) + translationManager.emptyString
                                 appWindow.toolTip.x = pos.x - appWindow.toolTip.width
-//                                if(appWindow.toolTip.height > 30)
-//                                    pos.y -= appWindow.toolTip.height - 30
+                                appWindow.toolTip.tipX = appWindow.toolTip.width - 10
                                 appWindow.toolTip.y = pos.y
                                 appWindow.toolTip.visible = true
                                 appWindow.toolTip.z = 3

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -92,7 +92,7 @@ Rectangle {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: height
-            color: containsMouse ? "#6B0072" : "#000000"
+            color: containsMouse || appWindow.whatIsEnable ? "#6B0072" : "#000000"
 
             Image {
                 anchors.centerIn: parent
@@ -103,6 +103,8 @@ Rectangle {
                 id: whatIsArea
                 anchors.fill: parent
                 onClicked: {
+
+                    appWindow.whatIsEnable = !appWindow.whatIsEnable
 
                 }
             }

--- a/main.qml
+++ b/main.qml
@@ -32,6 +32,7 @@ import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
 import QtQuick.Dialogs 1.2
 import Qt.labs.settings 1.0
+import QtQuick.Layouts 1.1
 
 import moneroComponents.Wallet 1.0
 import moneroComponents.PendingTransaction 1.0
@@ -1028,12 +1029,6 @@ ApplicationWindow {
             state: "Transfer"
         }
 
-        TipItem {
-            id: tipItem
-            text: qsTr("send to the same destination") + translationManager.emptyString
-            visible: false
-        }
-
         MouseArea {
             id: frameArea
             property bool blocked: false
@@ -1244,17 +1239,15 @@ ApplicationWindow {
         Rectangle {
             id: toolTip
             property alias text: content.text
+            property alias tipX: tip.x
             width: content.width + 12
-            height: content.height + 17
+            height: content.height + 12
             color: "#FF6C3C"
-            //radius: 3
             visible:false;
 
             Image {
                 id: tip
                 anchors.top: parent.bottom
-                anchors.right: parent.right
-                anchors.rightMargin: 5
                 source: "../images/tip.png"
             }
 
@@ -1262,10 +1255,16 @@ ApplicationWindow {
                 id: content
                 anchors.horizontalCenter: parent.horizontalCenter
                 y: 6
-                lineHeight: 0.7
                 font.family: "Arial"
                 font.pixelSize: 12
                 color: "#FFFFFF"
+                wrapMode: Text.Wrap
+                onTextChanged: {
+                    // reset width
+                    width = undefined
+                    // expand if content is wide
+                    width = (contentWidth > 150) ? 200 : contentWidth
+                }
             }
         }
 

--- a/main.qml
+++ b/main.qml
@@ -1263,7 +1263,7 @@ ApplicationWindow {
                     // reset width
                     width = undefined
                     // expand if content is wide
-                    width = (contentWidth > 150) ? 200 : contentWidth
+                    width = (contentWidth > 200) ? 200 : contentWidth
                 }
             }
         }

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -60,7 +60,7 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Address") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
+        tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
     }
 
     StandardButton {
@@ -101,9 +101,8 @@ Rectangle {
         anchors.leftMargin: 17
         anchors.topMargin: 17
         text: qsTr("Payment ID <font size='2'>(Optional)</font>") + translationManager.emptyString
+        tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Payment ID</b><br/><br/>A unique user name used in<br/>the address book. It is not a<br/>transfer of information sent<br/>during the transfer")
-                + translationManager.emptyString
     }
 
     LineEdit {
@@ -124,8 +123,8 @@ Rectangle {
         anchors.leftMargin: 17
         anchors.topMargin: 17
         text: qsTr("Description <font size='2'>(Optional)</font>") + translationManager.emptyString
+        tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip test test</b><br/><br/>test line 2") + translationManager.emptyString
     }
 
     LineEdit {

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -142,7 +142,7 @@ Rectangle {
         anchors.topMargin: 17
         text: getSelectedAmount()
         fontSize: 14
-        tipText: qsTr("<b>Total amount of selected payments</b>") + translationManager.emptyString
+        tipText: qsTr("Total amount of selected payments") + translationManager.emptyString
     }
 
 
@@ -221,7 +221,6 @@ Rectangle {
         width: 156
         text: qsTr("Date from") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     DatePicker {
@@ -246,7 +245,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("To") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     DatePicker {
@@ -328,7 +326,6 @@ Rectangle {
         width: 156
         text: qsTr("Type of transaction") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     ListModel {
@@ -363,7 +360,6 @@ Rectangle {
         width: 156
         text: qsTr("Amount from") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     LineEdit {
@@ -395,7 +391,6 @@ Rectangle {
         width: 156
         text: qsTr("To") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     LineEdit {

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -94,6 +94,7 @@ Rectangle {
                     id: soloMinerThreadsLabel
                     color: "#4A4949"
                     text: qsTr("CPU threads") + translationManager.emptyString
+                    tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                     fontSize: 16
                     Layout.preferredWidth: 120
                 }

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -175,7 +175,7 @@ Rectangle {
         anchors.right: parent.right
 
         spacing: 20
-        property int labelWidth: 120
+        property int labelWidth: 140
         property int editWidth: 400
         property int lineEditFontSize: 12
         property int qrCodeSize: 240
@@ -188,6 +188,7 @@ Rectangle {
                 id: addressLabel
                 fontSize: 14
                 text: qsTr("Address") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 width: mainLayout.labelWidth
             }
 
@@ -217,6 +218,7 @@ Rectangle {
                 id: paymentIdLabel
                 fontSize: 14
                 text: qsTr("Payment ID") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 width: mainLayout.labelWidth
             }
 
@@ -271,6 +273,7 @@ Rectangle {
                 id: integratedAddressLabel
                 fontSize: 14
                 text: qsTr("Integrated address") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 width: mainLayout.labelWidth
             }
 
@@ -304,6 +307,7 @@ Rectangle {
                 id: amountLabel
                 fontSize: 14
                 text: qsTr("Amount") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 width: mainLayout.labelWidth
             }
 

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -197,6 +197,7 @@ Rectangle {
                 id: daemonFlagsLabel
                 color: "#4A4949"
                 text: qsTr("Daemon startup flags") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
             }
             LineEdit {
@@ -219,6 +220,7 @@ Rectangle {
                 Layout.fillWidth: true
                 color: "#4A4949"
                 text: qsTr("Daemon address") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
             }
 
@@ -247,6 +249,7 @@ Rectangle {
                 Layout.fillWidth: true
                 color: "#4A4949"
                 text: qsTr("Login (optional)") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
             }
 
@@ -300,6 +303,7 @@ Rectangle {
             Label {
                 color: "#4A4949"
                 text: qsTr("Layout settings") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
                 anchors.topMargin: 30
                 Layout.topMargin: 30
@@ -328,6 +332,7 @@ Rectangle {
                 id: logLevelLabel
                 color: "#4A4949"
                 text: qsTr("Log level") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
             }
 
@@ -370,6 +375,7 @@ Rectangle {
             Label {
                 color: "#4A4949"
                 text: qsTr("Version") + translationManager.emptyString
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
                 fontSize: 16
                 anchors.topMargin: 30
                 Layout.topMargin: 30

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -123,6 +123,7 @@ Rectangle {
           anchors.rightMargin: 17
           anchors.topMargin: 17
           text: qsTr("Amount") + translationManager.emptyString
+          tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
           fontSize: 14
       }
 
@@ -133,6 +134,7 @@ Rectangle {
           fontSize: 14
           x: (parent.width - 17) / 2 + 17
           text: qsTr("Transaction priority") + translationManager.emptyString
+          tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
       }
 
 
@@ -233,6 +235,7 @@ Rectangle {
           text: qsTr("<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style>\
                       Address <font size='2'>  ( Paste in or select from </font> <a href='#'>Address book</a><font size='2'> )</font>")
                 + translationManager.emptyString
+          tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
 
           onLinkActivated: appWindow.showPageRequest("AddressBook")
       }
@@ -328,6 +331,7 @@ Rectangle {
           anchors.topMargin: 17
           fontSize: 14
           text: qsTr("Payment ID <font size='2'>( Optional )</font>") + translationManager.emptyString
+          tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
       }
 
       // payment id input
@@ -354,6 +358,7 @@ Rectangle {
           fontSize: 14
           text: qsTr("Description <font size='2'>( Optional )</font>")
                 + translationManager.emptyString
+          tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
       }
 
       LineEdit {
@@ -472,6 +477,7 @@ Rectangle {
                 id: privacyLabel
                 fontSize: 14
                 text: ""
+                tipText: qsTr("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ") + translationManager.emptyString
             }
 
             Label {


### PR DESCRIPTION
Fixes #684 

Adds tip text to all labels (se screenshot).
 
Known issues: 
- The [?] button is only visible in custom title bar. When native bar is used we need to move the button somewhere else. 
- I've added placeholder text to all labels now to make testing easier. They have to be replaced or removed before next release. 
- When final help texts are added we probably need to adjust the positioning for some of the labels. 

![screenshot](https://cloud.githubusercontent.com/assets/5909557/25314060/8edd8ad4-283c-11e7-8d11-d5ad8a15dbb4.png)
