### PR TITLE
Enable smart mining

### DIFF
--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -107,8 +107,6 @@ Rectangle {
             }
 
             RowLayout {
-                // Disable this option until stable
-                visible: false
                 Layout.leftMargin: 125
                 CheckBox {
                     id: backgroundMining


### PR DESCRIPTION
Adds checkbox for smart/background mining. Doesn't work on mac until https://github.com/monero-project/monero/pull/1936 is merged. 

Fixes #682 