### PR TITLE
made changes so that start-gui.sh script can be called from anywhere …

### DIFF
--- a/linuxdeploy_helper.sh
+++ b/linuxdeploy_helper.sh
@@ -46,7 +46,9 @@ cat > $TARGET/start-gui.sh <<EOL
 export LD_LIBRARY_PATH=\`pwd\`/libs
 export QT_PLUGIN_PATH=\`pwd\`/plugins
 export QML2_IMPORT_PATH=\`pwd\`/qml
-./$GUI_EXEC
+# make it so that it can be called from anywhere and also through soft links
+SCRIPT_DIR="\$(dirname "\$(test -L "\${BASH_SOURCE[0]}" && readlink "\${BASH_SOURCE[0]}" || echo "\${BASH_SOURCE[0]}")")"
+"\$SCRIPT_DIR"/$GUI_EXEC
 EOL
 
 chmod +x $TARGET/start-gui.sh


### PR DESCRIPTION
…and also from or with symbolic links

Currently start-gui.sh has the limitation that it only works if you call it from the same directory where start-gui.sh is located. This 2-line fix removes this limitation, allowing start-gui.sh to be called from anywhere and also from soft links pointing to it. 

Line 52/54 is marked in red/green because there is a newline at end of line now
 