### PR TITLE
Use "Transaction speed" instead of "Transaction priority"

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -132,7 +132,7 @@ Rectangle {
           anchors.topMargin: 17
           fontSize: 14
           x: (parent.width - 17) / 2 + 17
-          text: qsTr("Transaction priority") + translationManager.emptyString
+          text: qsTr("Transaction speed") + translationManager.emptyString
       }
 
 


### PR DESCRIPTION
Easier for laypeople to understand, and corresponds with the new Slow/Default/Fast/Fastest terms in #678