### PR TITLE
Normalize build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
 (Tested on Ubuntu 16.04 x86, 16.10 x64, Gentoo x64 and Linux Mint 18 "Sarah" - Cinnamon x64)
 
-1. Install Monero dependencies.
+1. Install Monero dependencies
 
   - For Ubuntu and Mint
 
@@ -76,15 +76,15 @@ Packaging for your favorite distribution would be a welcome contribution!
 
 	`sudo emerge app-arch/xz-utils app-doc/doxygen dev-cpp/gtest dev-libs/boost dev-libs/expat dev-libs/openssl dev-util/cmake media-gfx/graphviz net-dns/unbound net-libs/ldns net-libs/miniupnpc sys-libs/libunwind`
 
-2. Grab an up-to-date copy of the monero-core repository.
+2. Grab an up-to-date copy of the monero-core repository
 
 	`git clone https://github.com/monero-project/monero-core.git`
 
-3. Go into the repository.
+3. Go into the repository
 
 	`cd monero-core`
 
-4. Install the GUI dependencies.
+4. Install the GUI dependencies
 
   - For Ubuntu 16.04 x86
 
@@ -114,7 +114,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
       `emerge dev-qt/qtmultimedia:5 media-gfx/zbar`
 
-5. Build the GUI.
+5. Build the GUI
 
   - For Ubuntu and Mint
 
@@ -124,9 +124,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
     `QT_SELECT=5 ./build.sh`
 
-6. Run the GUI client.
-
-	`./build/release/bin/monero-wallet-gui`
+The executable can be found in the build/release/bin folder.
 
 ### On OS X:
 
@@ -154,15 +152,15 @@ Packaging for your favorite distribution would be a welcome contribution!
 
     This is the directory where Qt 5.x is installed on **your** system
 
-6. Grab an up-to-date copy of the monero-core repository.
+6. Grab an up-to-date copy of the monero-core repository
 
   `git clone https://github.com/monero-project/monero-core.git`
 
-7. Go into the repository.
+7. Go into the repository
 
   `cd monero-core`
 
-8. Start the build:
+8. Start the build
 
   `./build.sh`
 
@@ -170,7 +168,7 @@ The executable can be found in the `build/release/bin` folder.
 
 **Note:** Workaround for "ERROR: Xcode not set up properly"
 
-Edit `$HOME/Qt/5.7/clang_64/mkspecs/features/mac/default_pre.prf`
+Edit `$HOME/Qt/5.8/clang_64/mkspecs/features/mac/default_pre.prf`
 
 replace
 `isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null")))`
@@ -185,33 +183,33 @@ More info: http://stackoverflow.com/a/35098040/1683164
 
 1. Install [msys2](http://msys2.github.io/), follow the instructions on that page on how to update packages to the latest versions
 
-2. Install monero dependencies as described in [monero documentation](https://github.com/monero-project/monero) into msys2 environment.
+2. Install monero dependencies as described in [monero documentation](https://github.com/monero-project/monero) into msys2 environment
    **As we only build application for x86, install only dependencies for x86 architecture (i686 in package name)**
    ```
    pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost
 
    ```
 
-3. Install git into msys2 environment:
+3. Install git into msys2 environment
 
     ```
     pacman -S git
     ```
 
-4. Install Qt5 from [official site](https://www.qt.io/download-open-source/).
+4. Install Qt5 from [official site](https://www.qt.io/download-open-source/)
    - download unified installer, run and select following options:
        - Qt > Qt 5.7 > MinGW 5.3.0 32 bit
        - Tools > MinGW 5.3.0
    - continue with installation
 
-5. Open ```MinGW-w64 Win32 Shell``` shell:
+5. Open ```MinGW-w64 Win32 Shell``` shell
 
    ```%MSYS_ROOT%\msys2_shell.cmd -mingw32```
 
    Where ```%MSYS_ROOT%``` will be ```c:\msys32``` if your host OS is x86-based or ```c:\msys64``` if your host OS
    is x64-based
 
-6. Install the latest version of boost, specificly the required static libraries:
+6. Install the latest version of boost, specificly the required static libraries
     ```
     cd
     wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2
@@ -221,13 +219,13 @@ More info: http://stackoverflow.com/a/35098040/1683164
     ./b2 --prefix=/mingw32/boost --layout=tagged --without-mpi --without-python toolset=gcc address-model=32 variant=debug,release link=static threading=multi runtime-link=static -j$(nproc) install
     ```
 
-7. Clone repository:
+7. Clone repository
     ```
     cd
     git clone https://github.com/monero-project/monero-core.git
     ```
 
-8. Build the GUI:
+8. Build the GUI
     ```
     cd monero-core
     export PATH=$(ls -rd /c/Qt/5.[6,7,8]/mingw53_32/bin | head -1):$PATH
@@ -235,4 +233,5 @@ More info: http://stackoverflow.com/a/35098040/1683164
     cd build
     make deploy
     ```
-    The resulting executable can be found in ```.\release\bin```
+
+The executable can be found in the ```.\release\bin``` directory.


### PR DESCRIPTION
Mostly cleaned up some formatting for building the GUI, particularly normalized the steps so as each step doesn't end with different symbols (colon vs period vs nothing). Also edited the QT error workaround so its version matched the installation version.