### PR TITLE
Ignore unstaged files in 'monero' submodule by default.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "monero"]
 	path = monero
 	url = https://github.com/monero-project/monero
-    ignore = dirty
+	ignore = all


### PR DESCRIPTION
When building `monero-core`, a lot of files are generated in the `monero` submodule.
This change prevents those generated files from being considered modified and cluttering up our commits.

Per https://git-scm.com/docs/gitmodules.html#gitmodules-all

> The submodule will never be considered modified (but will nonetheless show up in the output of status and commit when it has been staged).

My git-fu is still not very advanced... feel free to tell me this is a bad idea. :-)