### PR TITLE
Restore wallet: Adding space after 'Your wallet is stored in'

### DIFF
--- a/wizard/WizardManageWalletUI.qml
+++ b/wizard/WizardManageWalletUI.qml
@@ -242,7 +242,7 @@ ColumnLayout {
             Layout.fillWidth: true
             Layout.topMargin: 20
             fontSize: 14
-            text: qsTr("Your wallet is stored in") + fileUrlInput.text;
+            text: qsTr("Your wallet is stored in") + ": " + fileUrlInput.text;
         }
 
         LineEdit {


### PR DESCRIPTION
Just adding space and a colon between the sentence "Your wallet is stored in" and the path that follows.  I added the space _outside_ of the translated string so that existing translations would not break.

Here is a screenshot demonstrating the issue:
![2017-05-17_missing-space-restore-wallet](https://cloud.githubusercontent.com/assets/5115470/26132590/a82bc45c-3aa1-11e7-8b2b-87a451d8f3dd.png)
