### PR TITLE
Removing unused tipText strings which clutter up translations.

### DIFF
--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -60,7 +60,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Address") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     StandardButton {
@@ -102,8 +101,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Payment ID <font size='2'>(Optional)</font>") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Payment ID</b><br/><br/>A unique user name used in<br/>the address book. It is not a<br/>transfer of information sent<br/>during the transfer")
-                + translationManager.emptyString
     }
 
     LineEdit {
@@ -125,7 +122,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Description <font size='2'>(Optional)</font>") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip test test</b><br/><br/>test line 2") + translationManager.emptyString
     }
 
     LineEdit {

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -144,7 +144,6 @@ Rectangle {
         anchors.topMargin: 17
         text: getSelectedAmount()
         fontSize: 14
-        tipText: qsTr("<b>Total amount of selected payments</b>") + translationManager.emptyString
     }
 
 
@@ -158,7 +157,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Address")
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     LineEdit {
@@ -199,7 +197,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("Description <font size='2'>(Local database)</font>") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b><br/><br/>test line 2") + translationManager.emptyString
     }
 
     LineEdit {
@@ -225,7 +222,6 @@ Rectangle {
         width: 156
         text: qsTr("Date from") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     DatePicker {
@@ -252,7 +248,6 @@ Rectangle {
         anchors.topMargin: 17
         text: qsTr("To") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     DatePicker {
@@ -338,7 +333,6 @@ Rectangle {
         width: 156
         text: qsTr("Type of transaction") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     ListModel {
@@ -375,7 +369,6 @@ Rectangle {
         width: 156
         text: qsTr("Amount from") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     LineEdit {
@@ -409,7 +402,6 @@ Rectangle {
         width: 156
         text: qsTr("To") + translationManager.emptyString
         fontSize: 14
-        tipText: qsTr("<b>Tip tekst test</b>") + translationManager.emptyString
     }
 
     LineEdit {


### PR DESCRIPTION
Most of these are "Tip tekst test" and unfortunately this is adding noise to all translation files.
I am not sure why these were added, but they are not used in the UI and most are nonsense anyway.