### PR TITLE
Dutch translation updated and edited

### DIFF
--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -14,85 +14,54 @@
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="63"/>
-        <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="72"/>
+        <location filename="../pages/AddressBook.qml" line="71"/>
         <source>QRCODE</source>
         <translation>QRCODE</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="94"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="103"/>
+        <location filename="../pages/AddressBook.qml" line="102"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="105"/>
-        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
-        <translation>&lt;b&gt;Betaal-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Een unieke gebruikersnaam die gebruikt wordt in&lt;br/&gt;het adresboek. Deze wordt niet gebruikt voor&lt;br/&gt;het verzenden van informatie;br/&gt;tijdens de transfer</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="117"/>
+        <location filename="../pages/AddressBook.qml" line="114"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Plak 64 hexadecimale karakters</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="128"/>
-        <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="139"/>
+        <location filename="../pages/AddressBook.qml" line="135"/>
         <source>Give this entry a name or description</source>
         <translation>Geef deze vermelding een naam of omschrijving</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="155"/>
+        <location filename="../pages/AddressBook.qml" line="151"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="160"/>
+        <location filename="../pages/AddressBook.qml" line="156"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="159"/>
         <source>Invalid address</source>
         <translation>Ongeldig adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="167"/>
+        <location filename="../pages/AddressBook.qml" line="163"/>
         <source>Can&apos;t create entry</source>
         <translation>Kan vermelding niet opslaan</translation>
-    </message>
-    <message>
-        <source>Description &lt;font size=&apos;2&apos;&gt;(Local database)&lt;/font&gt;</source>
-        <translation type="vanished">Beschrijving &lt;font size=&apos;2&apos;&gt;(Lokale database)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <source>ADD</source>
-        <translation type="vanished">NIEUW</translation>
-    </message>
-    <message>
-        <source>Payment ID</source>
-        <translation type="vanished">Betaal-ID</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation type="vanished">Beschrijving</translation>
     </message>
 </context>
 <context>
@@ -100,7 +69,7 @@
     <message>
         <location filename="../components/AddressBookTable.qml" line="47"/>
         <source>No more results</source>
-        <translation>Geen verdere resultaten</translation>
+        <translation>Verder geen resultaten</translation>
     </message>
     <message>
         <location filename="../components/AddressBookTable.qml" line="104"/>
@@ -113,12 +82,12 @@
     <message>
         <location filename="../BasicPanel.qml" line="97"/>
         <source>Locked Balance:</source>
-        <translation>Onbeschikbaar saldo:</translation>
+        <translation>Vergrendeld saldo:</translation>
     </message>
     <message>
         <location filename="../BasicPanel.qml" line="110"/>
         <source>78.9239845</source>
-        <translation type="unfinished"></translation>
+        <translation>78,9239845</translation>
     </message>
     <message>
         <location filename="../BasicPanel.qml" line="133"/>
@@ -128,7 +97,7 @@
     <message>
         <location filename="../BasicPanel.qml" line="146"/>
         <source>2324.9239845</source>
-        <translation type="unfinished"></translation>
+        <translation>2324,9239845</translation>
     </message>
 </context>
 <context>
@@ -141,23 +110,11 @@
     <message>
         <location filename="../components/DaemonConsole.qml" line="128"/>
         <source>command + enter (e.g help)</source>
-        <translation>commando + enter (b.v. help)</translation>
+        <translation>opdracht + enter (b.v. help)</translation>
     </message>
 </context>
 <context>
     <name>DaemonManagerDialog</name>
-    <message>
-        <source>Daemon doesn&apos;t appear to be running</source>
-        <translation type="vanished">Node lijkt niet actief te zijn</translation>
-    </message>
-    <message>
-        <source>Start daemon</source>
-        <translation type="vanished">Node starten</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
-    </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
         <source>Starting Monero daemon in %1 seconds</source>
@@ -172,17 +129,6 @@
         <location filename="../components/DaemonManagerDialog.qml" line="132"/>
         <source>Use custom settings</source>
         <translation>Gebruik aangepaste instellingen</translation>
-    </message>
-</context>
-<context>
-    <name>DaemonProgress</name>
-    <message>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation type="vanished">Blokken synchroniseren %1/%2</translation>
-    </message>
-    <message>
-        <source>Synchronizing blocks</source>
-        <translation type="vanished">Blokken synchroniseren</translation>
     </message>
 </context>
 <context>
@@ -208,7 +154,7 @@
     <message>
         <location filename="../components/DashboardTable.qml" line="47"/>
         <source>No more results</source>
-        <translation>Geen verdere resultaten</translation>
+        <translation>Verder geen resultaten</translation>
     </message>
     <message>
         <location filename="../components/DashboardTable.qml" line="137"/>
@@ -229,15 +175,6 @@
 <context>
     <name>History</name>
     <message>
-        <location filename="../pages/History.qml" line="228"/>
-        <location filename="../pages/History.qml" line="255"/>
-        <location filename="../pages/History.qml" line="341"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="412"/>
-        <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../pages/History.qml" line="135"/>
         <source>Filter transaction history</source>
         <translation>Filter transactiegeschiedenis</translation>
@@ -248,63 +185,38 @@
         <translation> geselecteerd: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="147"/>
-        <source>&lt;b&gt;Total amount of selected payments&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Totaalbedrag van geselecteerde betalingen&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="281"/>
+        <location filename="../pages/History.qml" line="276"/>
         <source>Filter</source>
         <translation>Filteren</translation>
     </message>
     <message>
-        <source>Incremental search</source>
-        <translation type="vanished">Incrementeel zoeken</translation>
-    </message>
-    <message>
-        <source>Search transfers for a given string</source>
-        <translation type="vanished">Betalingen zoeken met een bepaalde term</translation>
-    </message>
-    <message>
-        <source>Type search string</source>
-        <translation type="vanished">Zoekterm ingeven</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="185"/>
+        <location filename="../pages/History.qml" line="183"/>
         <source>Type for incremental search...</source>
         <translation>Begin te typen voor incrementeel zoeken...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="226"/>
+        <location filename="../pages/History.qml" line="223"/>
         <source>Date from</source>
-        <translation>Startdatum</translation>
+        <translation>Datum van</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="253"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="249"/>
+        <location filename="../pages/History.qml" line="403"/>
         <source>To</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <source>FILTER</source>
-        <translation type="vanished">FILTEREN</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="319"/>
+        <location filename="../pages/History.qml" line="314"/>
         <source>Advanced filtering</source>
         <translation>Geavanceerd filteren</translation>
     </message>
     <message>
-        <source>Advance filtering</source>
-        <translation type="vanished">Geavanceerd filteren</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="339"/>
+        <location filename="../pages/History.qml" line="334"/>
         <source>Type of transaction</source>
         <translation>Soort transactie</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="370"/>
         <source>Amount from</source>
         <translation>Bedrag van</translation>
     </message>
@@ -314,7 +226,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="78"/>
         <source>No more results</source>
-        <translation>Geen verdere resultaten</translation>
+        <translation>Verder geen resultaten</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
@@ -391,19 +303,9 @@
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="135"/>
-        <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../LeftPanel.qml" line="178"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="181"/>
-        <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="281"/>
@@ -419,10 +321,6 @@
         <location filename="../LeftPanel.qml" line="332"/>
         <source>R</source>
         <translation>R</translation>
-    </message>
-    <message>
-        <source>Verify payment</source>
-        <translation type="vanished">Betaling controleren</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="425"/>
@@ -483,7 +381,7 @@
     <message>
         <location filename="../LeftPanel.qml" line="448"/>
         <source>Sign/verify</source>
-        <translation>Signeren/verifiëren</translation>
+        <translation>Ondertekenen/verifiëren</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="449"/>
@@ -509,14 +407,6 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <source>Balance:</source>
-        <translation type="vanished">Saldo:</translation>
-    </message>
-    <message>
-        <source>Unlocked Balance:</source>
-        <translation type="vanished">Beschikbaar Saldo:</translation>
-    </message>
-    <message>
         <location filename="../MiddlePanel.qml" line="46"/>
         <source>Balance</source>
         <translation>Saldo</translation>
@@ -524,7 +414,7 @@
     <message>
         <location filename="../MiddlePanel.qml" line="48"/>
         <source>Unlocked Balance</source>
-        <translation>Beschikbaar Saldo</translation>
+        <translation>Beschikbaar saldo</translation>
     </message>
 </context>
 <context>
@@ -540,33 +430,9 @@
         <translation>(alleen beschikbaar voor lokale nodes)</translation>
     </message>
     <message>
-        <source>Mining helps the Monero network build resilience.&lt;br&gt;</source>
-        <translation type="vanished">Minen help het Monero-netwerk weerstand op te bouwen.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The more mining is done, the harder it is to attack the network.&lt;br&gt;</source>
-        <translation type="vanished">Hoe meer er gemined wordt, des te moeilijker het is om het Monero-netwerk aan te vallen.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Mining also gives you a small chance to earn some Monero.&lt;br&gt;</source>
-        <translation type="vanished">Minen geeft je een kleine kans om Monero te verdienen.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Your computer will search for Monero block solutions.&lt;br&gt;</source>
-        <translation type="vanished">Uw computer zal zoeken naar Monero blok-oplossingen.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>If you find a block, you will get the associated reward.&lt;br&gt;</source>
-        <translation type="vanished">Als u een blok vindt, zult u de bijbehorende beloning ontvangen.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Mining helps the Monero network build resilience. The more mining is done, the harder it is to attack the network. Mining also gives you a small chance to earn some Monero. Your computer will search for Monero block solutions. If you find a block, you will get the associated reward.</source>
-        <translation type="vanished">Minen help het Monero-netwerk weerstand op te bouwen. Hoe meer er gemined wordt, des te moeilijker het is om het Monero-netwerk aan te vallen. Minen geeft je een kleine kans om Monero te verdienen. Uw computer zal zoeken naar Monero blok-oplossingen. Als u een blok vindt, zult u de bijbehorende beloning ontvangen.</translation>
-    </message>
-    <message>
         <location filename="../pages/Mining.qml" line="86"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
-        <translation>Minen met uw computer helpt het Monero-netwerk sterker te worden. Hoe meer individuen er minen, des te moeilijker het is om het Monero-netwerk aan te vallen. Ieder beetje helpt dus.&lt;br&gt; &lt;br&gt; Minen geeft je ook een kleine kans om Monero te verdienen. Uw computer zal namelijk specifieke tekenreeksen berekenen en zodoende op zoek gaan naar Monero blok-oplossingen. Als u een blok vindt, zult u de bijbehorende beloning ontvangen. Veel success!</translation>
+        <translation>Minen met uw computer helpt het Monero-netwerk sterker te worden. Hoe meer individuen er minen, des te moeilijker het is om het Monero-netwerk aan te vallen. Ieder beetje helpt dus.&lt;br&gt; &lt;br&gt; Minen geeft u ook een kleine kans om Monero te verdienen. Uw computer zal namelijk specifieke tekenreeksen berekenen en zodoende op zoek gaan naar Monero blok-oplossingen. Als u een blok vindt, ontvangt u de bijbehorende beloning. Veel success!</translation>
     </message>
     <message>
         <location filename="../pages/Mining.qml" line="96"/>
@@ -636,7 +502,7 @@
     <message>
         <location filename="../pages/Mining.qml" line="208"/>
         <source>Status: </source>
-        <translation>Status:</translation>
+        <translation>Status: </translation>
     </message>
 </context>
 <context>
@@ -644,7 +510,7 @@
     <message>
         <location filename="../components/MobileHeader.qml" line="94"/>
         <source>Unlocked Balance:</source>
-        <translation type="unfinished">Beschikbaar Saldo:</translation>
+        <translation>Beschikbaar saldo:</translation>
     </message>
 </context>
 <context>
@@ -685,12 +551,12 @@
     <message>
         <location filename="../components/PasswordDialog.qml" line="79"/>
         <source>Please enter wallet password</source>
-        <translation>Portemonnee wachtwoord invullen alstublieft</translation>
+        <translation>Vul het wachtwoord voor de portemonnee in</translation>
     </message>
     <message>
         <location filename="../components/PasswordDialog.qml" line="79"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
-        <translation>Vul aub portemonnee wachtwoord in voor:&lt;br&gt;</translation>
+        <translation>Vul het wachtwoord van de portemonnee in voor:&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../components/PasswordDialog.qml" line="156"/>
@@ -700,23 +566,11 @@
     <message>
         <location filename="../components/PasswordDialog.qml" line="171"/>
         <source>Ok</source>
-        <translation>Ok</translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>PrivacyLevelSmall</name>
-    <message>
-        <source>LOW</source>
-        <translation type="vanished">LAAG</translation>
-    </message>
-    <message>
-        <source>MEDIUM</source>
-        <translation type="vanished">GEMIDDELD</translation>
-    </message>
-    <message>
-        <source>HIGH</source>
-        <translation type="vanished">HOOG</translation>
-    </message>
     <message>
         <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
         <source>Low</source>
@@ -735,10 +589,6 @@
 </context>
 <context>
     <name>ProgressBar</name>
-    <message>
-        <source>Synchronizing blocks %1/%2</source>
-        <translation type="vanished">Blokken synchroniseren %1/%2</translation>
-    </message>
     <message>
         <location filename="../components/ProgressBar.qml" line="43"/>
         <source>Establishing connection...</source>
@@ -838,10 +688,6 @@
         <translation>Genereer Betaal-ID voor geïntegreerd adres</translation>
     </message>
     <message>
-        <source>ReadOnly wallet integrated address displayed here</source>
-        <translation type="vanished">Geïntegreerd adres alleen-lezen portemonnee wordt hier weergegeven</translation>
-    </message>
-    <message>
         <location filename="../pages/Receive.qml" line="388"/>
         <source>Save QrCode</source>
         <translation>QR-Code opslaan</translation>
@@ -849,7 +695,7 @@
     <message>
         <location filename="../pages/Receive.qml" line="389"/>
         <source>Failed to save QrCode to </source>
-        <translation>Opslaan van QR-Code is mislukt</translation>
+        <translation>QR-code niet opgeslagen in </translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="400"/>
@@ -860,10 +706,6 @@
         <location filename="../pages/Receive.qml" line="222"/>
         <source>Payment ID</source>
         <translation>Betaal-ID</translation>
-    </message>
-    <message>
-        <source>16 or 64 hexadecimal characters</source>
-        <translation type="vanished">16 of 64 hexadecimale tekens</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="309"/>
@@ -888,7 +730,7 @@
     <message>
         <location filename="../pages/Receive.qml" line="344"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een eenvoudige verkoop tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik hier om een willekeurige betaal-ID te maken voor een nieuwe klant&lt;/p&gt; &lt;p&gt;Laat je klant deze QR code scannen om een betaling uit te voeren (als die klant over software beschikt die QR codes kan scannen).&lt;/p&gt;&lt;p&gt;Deze pagina zal automatisch de blockchain en transactiepoel scannen op inkomende transacties met behulp van deze QR code. Als je een bedrag invult, zal er ook gecontroleerd worden of het complete bedrag ontvangen is.&lt;/p&gt;Het is aan jou om eventuele onbevestigde transacties te accepteren of niet. Het is zeer waarschijnlijk dat deze op korte termijn bevestigd zullen worden, maar er is nog steeds een mogelijkheid dat dit niet gebeurt. Bij grote bedragen is het dus aan te raden te wachten op één of meer bevestigingen.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een eenvoudige verkooptracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik hier om een willekeurige betaal-ID te maken voor een nieuwe klant&lt;/p&gt; &lt;p&gt;Laat uw klant deze QR-code scannen om een betaling uit te voeren (als die klant over software beschikt die QR-codes kan scannen).&lt;/p&gt;&lt;p&gt;Deze pagina zal automatisch de blockchain en transactiepoel doorzoeken op inkomende transacties met behulp van deze QR-code. Als u een bedrag invult, wordt er ook gecontroleerd of het complete bedrag ontvangen is.&lt;/p&gt;Het is aan u om eventuele onbevestigde transacties te accepteren of niet. Het is zeer waarschijnlijk dat deze op korte termijn bevestigd zullen worden, maar er is nog steeds een mogelijkheid dat dit niet gebeurt. Bij grote bedragen is het dus aan te raden om te wachten op een of meer bevestigingen.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="254"/>
@@ -924,7 +766,7 @@
     <message>
         <location filename="../components/SearchInput.qml" line="69"/>
         <source>Search by...</source>
-        <translation>Zoeken op…</translation>
+        <translation>Zoeken op...</translation>
     </message>
     <message>
         <location filename="../components/SearchInput.qml" line="228"/>
@@ -935,10 +777,6 @@
 <context>
     <name>Settings</name>
     <message>
-        <source>Click button to show seed</source>
-        <translation type="vanished">Klik op de knop om de hersteltekst te tonen</translation>
-    </message>
-    <message>
         <location filename="../pages/Settings.qml" line="171"/>
         <location filename="../pages/Settings.qml" line="539"/>
         <source>Error</source>
@@ -947,44 +785,32 @@
     <message>
         <location filename="../pages/Settings.qml" line="525"/>
         <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Hersteltekst en sleutels van portemonnee</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="527"/>
         <source>Secret view key</source>
-        <translation type="unfinished"></translation>
+        <translation>Geheime alleen-lezen sleutel</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="528"/>
         <source>Public view key</source>
-        <translation type="unfinished"></translation>
+        <translation>Openbare alleen-lezen sleutel</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="529"/>
         <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
+        <translation>Geheime bestedingssleutel</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="530"/>
         <source>Public spend key</source>
-        <translation type="unfinished"></translation>
+        <translation>Openbare bestedingssleutel</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="540"/>
         <source>Wrong password</source>
         <translation>Verkeerd wachtwoord</translation>
-    </message>
-    <message>
-        <source>Mnemonic seed: </source>
-        <translation type="vanished">Hersteltekst:</translation>
-    </message>
-    <message>
-        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation type="vanished">Het is erg belangrijk om dit op te schrijven, omdat dit de enige back-up is die u heeft voor uw portemonnee.</translation>
-    </message>
-    <message>
-        <source>Show seed</source>
-        <translation type="vanished">Toon hersteltekst</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="306"/>
@@ -995,10 +821,6 @@
         <location filename="../pages/Settings.qml" line="72"/>
         <source>Manage wallet</source>
         <translation>Portemonnee beheren</translation>
-    </message>
-    <message>
-        <source>Close current wallet and open wizard</source>
-        <translation type="vanished">Sluit huidige portemonnee en open de configuratie-assistent</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="88"/>
@@ -1026,18 +848,14 @@
         <translation>Stop lokale node</translation>
     </message>
     <message>
-        <source>Show log</source>
-        <translation type="vanished">Bekijk log</translation>
-    </message>
-    <message>
         <location filename="../pages/Settings.qml" line="509"/>
         <source>Daemon log</source>
-        <translation>Node log</translation>
+        <translation>Node-log</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="322"/>
         <source>Hostname / IP</source>
-        <translation>Hostnaam / IP</translation>
+        <translation>Hostnaam/IP-adres</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="239"/>
@@ -1047,7 +865,7 @@
     <message>
         <location filename="../pages/Settings.qml" line="286"/>
         <source>Daemon startup flags</source>
-        <translation>Node start argumenten</translation>
+        <translation>Startargumenten voor node</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="265"/>
@@ -1058,32 +876,32 @@
     <message>
         <location filename="../pages/Settings.qml" line="120"/>
         <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Toon hersteltekst en sleutels</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="163"/>
         <source>Rescan wallet balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Saldo van portemonnee opzoeken</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="172"/>
         <source>Error: </source>
-        <translation type="unfinished">Fout:</translation>
+        <translation>Fout: </translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="177"/>
         <source>Information</source>
-        <translation type="unfinished">Informatie</translation>
+        <translation>Informatie</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="178"/>
         <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">Met succes de uitgaven doorzocht</translation>
+        <translation>De uitgaven zijn doorzocht</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="257"/>
         <source>Blockchain location</source>
-        <translation type="unfinished"></translation>
+        <translation>Locatie van blockchain</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="331"/>
@@ -1093,7 +911,7 @@
     <message>
         <location filename="../pages/Settings.qml" line="342"/>
         <source>Login (optional)</source>
-        <translation>Loginnaam (optioneel)</translation>
+        <translation>Inlognaam (optioneel)</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="355"/>
@@ -1113,46 +931,42 @@
     <message>
         <location filename="../pages/Settings.qml" line="573"/>
         <source>Please choose a folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Kies een map</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="582"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Waarschuwing</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="585"/>
         <source>Error: Filesystem is read only</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout: het bestandssysteem is alleen-lezen</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="589"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
-        <translation type="unfinished"></translation>
+        <translation>Waarschuwing: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="591"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
-        <translation type="unfinished"></translation>
+        <translation>Let op: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="595"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
-        <translation type="unfinished"></translation>
+        <translation>LMDB-map niet gevonden. Er wordt een nieuwe map gemaakt.</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
         <source>Cancel</source>
-        <translation type="unfinished">Annuleren</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Opslaan</translation>
+        <translation>Annuleren</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="398"/>
         <source>Layout settings</source>
-        <translation>Opmaak instellingen</translation>
+        <translation>Opmaakinstellingen</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="415"/>
@@ -1162,7 +976,7 @@
     <message>
         <location filename="../pages/Settings.qml" line="426"/>
         <source>Log level</source>
-        <translation>Log niveau</translation>
+        <translation>Logniveau</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="460"/>
@@ -1177,16 +991,12 @@
     <message>
         <location filename="../pages/Settings.qml" line="492"/>
         <source>GUI version: </source>
-        <translation>GUI versie:</translation>
+        <translation>GUI-versie: </translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="499"/>
         <source>Embedded Monero version: </source>
-        <translation>Ingebouwde Monero versie:</translation>
-    </message>
-    <message>
-        <source>Wallet mnemonic seed</source>
-        <translation type="vanished">Portemonnee hersteltekst</translation>
+        <translation>Ingebouwde Monero-versie: </translation>
     </message>
 </context>
 <context>
@@ -1214,7 +1024,7 @@
     <message>
         <location filename="../pages/Sign.qml" line="111"/>
         <source>Sign a message or file contents with your address:</source>
-        <translation>Signeer een bericht of bestandsinhoud met uw adres:</translation>
+        <translation>Onderteken een bericht of bestandsinhoud met uw adres:</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="122"/>
@@ -1231,7 +1041,7 @@
         <location filename="../pages/Sign.qml" line="156"/>
         <location filename="../pages/Sign.qml" line="231"/>
         <source>Sign</source>
-        <translation>Signeer</translation>
+        <translation>Ondertekenen</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="184"/>
@@ -1242,13 +1052,13 @@
         <location filename="../pages/Sign.qml" line="197"/>
         <location filename="../pages/Sign.qml" line="368"/>
         <source>Select</source>
-        <translation>Selecteer</translation>
+        <translation>Selecteren</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="327"/>
         <location filename="../pages/Sign.qml" line="401"/>
         <source>Verify</source>
-        <translation>Verifiëer</translation>
+        <translation>Verifiëren</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="355"/>
@@ -1261,18 +1071,10 @@
         <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Adres voor ondertekenen &lt;font size=&apos;2&apos;&gt;  (Vul in of slecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
-        <source>SIGN</source>
-        <translation type="vanished">ONDERTEKENEN</translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="172"/>
         <location filename="../pages/Sign.qml" line="343"/>
         <source>Or file:</source>
         <translation>Of bestand:</translation>
-    </message>
-    <message>
-        <source>SELECT</source>
-        <translation type="vanished">SELECTEER</translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="212"/>
@@ -1298,17 +1100,9 @@
         <translation>Het te verifiëren bericht</translation>
     </message>
     <message>
-        <source>VERIFY</source>
-        <translation type="vanished">VERIFIËREN</translation>
-    </message>
-    <message>
         <location filename="../pages/Sign.qml" line="383"/>
         <source>Filename with message to verify</source>
         <translation>Bestandsnaam met bericht om te verifiëren</translation>
-    </message>
-    <message>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Handtekening adres &lt;font size=&apos;2&apos;&gt;  ( Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adres&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;boek )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
@@ -1329,30 +1123,50 @@
     <message>
         <location filename="../components/StandardDropdown.qml" line="197"/>
         <source>Low (x1 fee)</source>
-        <translation>Laag (×1 vergoeding)</translation>
+        <translation>Laag (vergoeding × 1)</translation>
     </message>
     <message>
         <location filename="../components/StandardDropdown.qml" line="198"/>
         <source>Medium (x20 fee)</source>
-        <translation>Gemiddeld (×20 vergoeding)</translation>
+        <translation>Gemiddeld (vergoeding × 20)</translation>
     </message>
     <message>
         <location filename="../components/StandardDropdown.qml" line="199"/>
         <source>High (x166 fee)</source>
-        <translation>Hoog (×166 vergoeding)</translation>
+        <translation>Hoog (vergoeding × 166)</translation>
     </message>
     <message>
         <location filename="../components/StandardDropdown.qml" line="200"/>
+        <source>Slow (x0.25 fee)</source>
+        <translation>Langzaam (vergoeding × 0,25)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <source>Default (x1 fee)</source>
+        <translation>Normaal (vergoeding × 1)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <source>Fast (x5 fee)</source>
+        <translation>Snel (vergoeding × 5)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <source>Fastest (x41.5 fee)</source>
+        <translation>Razendsnel (vergoeding × 41,5)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>Sent</source>
         <translation>Verzonden</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Received</source>
         <translation>Ontvangen</translation>
     </message>
@@ -1365,13 +1179,9 @@
         <translation>&lt;b&gt;Kopieer adres naar klembord&lt;/b&gt;</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Send to same destination&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Verstuur naar hetzelfde adres&lt;/b&gt;</translation>
-    </message>
-    <message>
         <location filename="../components/TableDropdown.qml" line="183"/>
         <source>&lt;b&gt;Send to this address&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Verstuur naar dit adres&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../components/TableDropdown.qml" line="184"/>
@@ -1410,18 +1220,6 @@
 <context>
     <name>TickDelegate</name>
     <message>
-        <source>LOW</source>
-        <translation type="vanished">LAAG</translation>
-    </message>
-    <message>
-        <source>MEDIUM</source>
-        <translation type="vanished">GEMIDDELD</translation>
-    </message>
-    <message>
-        <source>HIGH</source>
-        <translation type="vanished">HOOG</translation>
-    </message>
-    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
         <source>Normal</source>
         <translation>Normaal</translation>
@@ -1450,59 +1248,19 @@
         <translation>Prioriteit transactie</translation>
     </message>
     <message>
-        <source>LOW</source>
-        <translation type="vanished">LAAG</translation>
-    </message>
-    <message>
-        <source>MEDIUM</source>
-        <translation type="vanished">GEMIDDELD</translation>
-    </message>
-    <message>
-        <source>HIGH</source>
-        <translation type="vanished">HOOG</translation>
-    </message>
-    <message>
         <location filename="../pages/Transfer.qml" line="91"/>
         <source></source>
         <translation></translation>
     </message>
     <message>
-        <source>or ALL</source>
-        <translation type="vanished">of ALLES</translation>
-    </message>
-    <message>
-        <source>LOW (x1 fee)</source>
-        <translation type="vanished">LAAG (×1 vergoeding)</translation>
-    </message>
-    <message>
-        <source>MEDIUM (x20 fee)</source>
-        <translation type="vanished">GEMIDDELD (×20 vergoeding)</translation>
-    </message>
-    <message>
-        <source>HIGH (x166 fee)</source>
-        <translation type="vanished">HOOG (×166 vergoeding)</translation>
-    </message>
-    <message>
-        <source>Privacy level</source>
-        <translation type="vanished">Privacyniveau</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="474"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <source>Description &lt;font size=&apos;2&apos;&gt;( Optional - saved to local wallet history )&lt;/font&gt;</source>
-        <translation type="vanished">Beschrijving &lt;font size=&apos;2&apos;&gt;( Optioneel - opgeslagen in de lokale portemonnee-geschiedenis )&lt;/font&gt;</translation>
-    </message>
-    <message>
         <location filename="../pages/Transfer.qml" line="66"/>
         <source>OpenAlias error</source>
-        <translation>OpenAlias fout</translation>
+        <translation>Fout in OpenAlias</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="78"/>
@@ -1516,133 +1274,117 @@
         <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start lokale node&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
-        <source>all</source>
-        <translation type="vanished">alles</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="193"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Low (x1 fee)</source>
-        <translation>Laag (×1 vergoeding)</translation>
+        <translation>Laag (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="194"/>
+        <location filename="../pages/Transfer.qml" line="198"/>
         <source>Medium (x20 fee)</source>
-        <translation>Gemiddeld (×20 vergoeding)</translation>
+        <translation>Gemiddeld (vergoeding × 20)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
+        <location filename="../pages/Transfer.qml" line="199"/>
         <source>High (x166 fee)</source>
-        <translation>Hoog (×166 vergoeding)</translation>
+        <translation>Hoog (vergoeding × 166)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="202"/>
+        <location filename="../pages/Transfer.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Langzaam (vergoeding × 0,25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="203"/>
+        <location filename="../pages/Transfer.qml" line="207"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished">Normaal (×4 vergoeding) {1 ?}</translation>
+        <translation>Normaal (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="204"/>
+        <location filename="../pages/Transfer.qml" line="208"/>
         <source>Fast (x5 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Snel (vergoeding × 5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="205"/>
+        <location filename="../pages/Transfer.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Razendsnel (vergoeding × 41,5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="233"/>
+        <location filename="../pages/Transfer.qml" line="237"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
         <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Addresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="251"/>
+        <location filename="../pages/Transfer.qml" line="255"/>
         <source>QR Code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="281"/>
+        <location filename="../pages/Transfer.qml" line="285"/>
         <source>Resolve</source>
         <translation>Oplossen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="303"/>
         <source>No valid address found at this OpenAlias address</source>
-        <translation>Geen geldig adres gevonden onder dit OpenAlias adres</translation>
+        <translation>Geen geldig adres gevonden voor dit OpenAlias-adres</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="304"/>
+        <location filename="../pages/Transfer.qml" line="308"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
-        <translation>Adres gevonden, maar DNSSEC handtekeningen konden niet geverifiëerd worden, dus het adres kan mogelijk gespoofed en dus ongeldig zijn</translation>
+        <translation>Adres gevonden, maar de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="306"/>
+        <location filename="../pages/Transfer.qml" line="310"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
-        <translation>Geen geldig adres gevonden onder het opgegeven OpenAlias adres, en de DNSSEC handtekeningen konden niet geverifiëerd worden, dus het adres kan mogelijk gespoofed en dus ongeldig zijn</translation>
+        <translation>Geen geldig adres gevonden onder het opgegeven OpenAlias-adres, en de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="309"/>
-        <location filename="../pages/Transfer.qml" line="312"/>
+        <location filename="../pages/Transfer.qml" line="313"/>
+        <location filename="../pages/Transfer.qml" line="316"/>
         <source>Internal error</source>
         <translation>Interne fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="315"/>
+        <location filename="../pages/Transfer.qml" line="319"/>
         <source>No address found</source>
         <translation>Geen adres gevonden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="355"/>
+        <location filename="../pages/Transfer.qml" line="359"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="367"/>
+        <location filename="../pages/Transfer.qml" line="371"/>
         <source>Saved to local wallet history</source>
         <translation>Wordt opgeslagen in de lokale portemonnee-geschiedenis</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="397"/>
+        <location filename="../pages/Transfer.qml" line="401"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="443"/>
+        <location filename="../pages/Transfer.qml" line="447"/>
         <source>Show advanced options</source>
         <translation>Laat geavanceerde opties zien</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="715"/>
+        <location filename="../pages/Transfer.qml" line="719"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
-        <translation type="unfinished"></translation>
+        <translation>Verbonden node is niet compatibel met de GUI.
+Upgrade of maak verbinding met een andere node</translation>
     </message>
     <message>
-        <source>Privacy level (ringsize 5)</source>
-        <translation type="vanished">Privacy niveau (ringgrootte 5)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="495"/>
+        <location filename="../pages/Transfer.qml" line="499"/>
         <source>Sweep Unmixable</source>
-        <translatorcomment>Lastig te vertalen deze. Misschien heeft iemand anders een beter idee dan, &quot;Schoonvegen van niet-te-mengen posten&quot;</translatorcomment>
-        <translation type="unfinished"></translation>
+        <translation>Onmengbare bedragen samenvoegen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="509"/>
+        <location filename="../pages/Transfer.qml" line="513"/>
         <source>Create tx file</source>
-        <translation>Maak TX bestand</translation>
-    </message>
-    <message>
-        <source>sign tx file</source>
-        <translation type="vanished">Signeer TX bestand</translation>
-    </message>
-    <message>
-        <source>submit tx file</source>
-        <translation type="vanished">Verzend TX bestand</translation>
+        <translation>Maak TX-bestand</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="175"/>
@@ -1650,159 +1392,121 @@ Please upgrade or connect to another daemon</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <source>Default (x4 fee)</source>
-        <translation type="vanished">Normaal (×4 vergoeding)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="531"/>
+        <location filename="../pages/Transfer.qml" line="535"/>
         <source>Sign tx file</source>
-        <translation>Signeer TX bestand</translation>
+        <translation>Onderteken TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="545"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>Submit tx file</source>
-        <translation>Verzend TX bestand</translation>
+        <translation>Verzend TX-bestand</translation>
     </message>
     <message>
-        <source>Rescan spent</source>
-        <translation type="vanished">Doorzoek uitgaven</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="578"/>
-        <location filename="../pages/Transfer.qml" line="634"/>
+        <location filename="../pages/Transfer.qml" line="582"/>
+        <location filename="../pages/Transfer.qml" line="638"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <source>Error: </source>
-        <translation type="vanished">Fout:</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="644"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="vanished">Met succes de uitgaven doorzocht</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
-        <location filename="../pages/Transfer.qml" line="628"/>
+        <location filename="../pages/Transfer.qml" line="571"/>
+        <location filename="../pages/Transfer.qml" line="632"/>
         <source>Please choose a file</source>
         <translation>Kies een bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="579"/>
+        <location filename="../pages/Transfer.qml" line="583"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Het laden van de niet-ondertekende transactie is mislukt: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="586"/>
+        <location filename="../pages/Transfer.qml" line="590"/>
         <source>
 Number of transactions: </source>
         <translation>
-Aantal transacties:</translation>
+Aantal transacties: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="588"/>
+        <location filename="../pages/Transfer.qml" line="592"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transactie #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="589"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>
 Recipient: </source>
         <translation>
-Ontvanger:</translation>
+Ontvanger: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>
 payment ID: </source>
         <translation>
-Betaal-ID:</translation>
+Betaal-ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="595"/>
         <source>
 Amount: </source>
         <translation>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="596"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="597"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgrootte: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="611"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="635"/>
+        <location filename="../pages/Transfer.qml" line="639"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan transactie niet insturen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="641"/>
+        <location filename="../pages/Transfer.qml" line="645"/>
         <source>Money sent successfully</source>
-        <translation>Geld is succesvol verstuurd</translation>
+        <translation>Het geld is verstuurd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="700"/>
-        <location filename="../pages/Transfer.qml" line="712"/>
+        <location filename="../pages/Transfer.qml" line="704"/>
+        <location filename="../pages/Transfer.qml" line="716"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portemonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <source>Connected daemon is not compatible with GUI.
-Please upgrade or connect to another daemon</source>
-        <translation type="vanished">Verbonden node is niet compatibel met de GUI.
-Graag upgraden of verbinden met een andere node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="724"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>
     <message>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Address &lt;font size=&apos;2&apos;&gt;  ( Type in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; book )&lt;/font&gt;</source>
-        <translation type="vanished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                    Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adres&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; boek)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="330"/>
+        <location filename="../pages/Transfer.qml" line="334"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="342"/>
+        <location filename="../pages/Transfer.qml" line="346"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 of 64 hexadecimale tekens</translation>
-    </message>
-    <message>
-        <source>Description &lt;font size=&apos;2&apos;&gt;( An optional description that will be saved to the local address book if entered )&lt;/font&gt;</source>
-        <translation type="vanished">Beschrijving &lt;font size=&apos;2&apos;&gt;(Een optionele beschrijving die opgeslagen wordt in het lokale adresboek)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <source>SEND</source>
-        <translation type="vanished">VERZENDEN</translation>
-    </message>
-    <message>
-        <source>SWEEP UNMIXABLE</source>
-        <translation type="obsolete">SAMENVOEGEN VAN NIET TE MENGEN BEDRAGEN</translation>
     </message>
 </context>
 <context>
@@ -1826,10 +1530,6 @@ Graag upgraden of verbinden met een andere node</translation>
         <location filename="../pages/TxKey.qml" line="105"/>
         <source> - the secret transaction key supplied by the sender</source>
         <translation> - de geheime transactiesleutel verstrekt door de verzender</translation>
-    </message>
-    <message>
-        <source>If a payment had several transactions then each must must be checked and the results combined.</source>
-        <translation type="vanished">Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
     </message>
     <message>
         <location filename="../pages/TxKey.qml" line="110"/>
@@ -1869,11 +1569,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../pages/TxKey.qml" line="185"/>
         <source>Transaction key</source>
-        <translation>Transactie sleutel</translation>
-    </message>
-    <message>
-        <source>CHECK</source>
-        <translation type="vanished">CONTROLE</translation>
+        <translation>Transactiesleutel</translation>
     </message>
 </context>
 <context>
@@ -1886,16 +1582,12 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="97"/>
         <source>Kickstart the Monero blockchain?</source>
-        <translation>De Monero blockchain starten?</translation>
-    </message>
-    <message>
-        <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation type="vanished">Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee. Op de volgende pagina wordt gevraagd om de hersteltekst te bevestigen om ervoor te zorgen dat de tekst op de juiste manier is overgenomen.</translation>
+        <translation>De Monero-blockchain starten?</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="115"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation>Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee.</translation>
+        <translation>Het is erg belangrijk om dit op te schrijven, want dit is de enige back-up die u nodig heeft voor uw portemonnee.</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="126"/>
@@ -1905,12 +1597,12 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
-        <translation>De modus voor schijfbehoud gebruikt substantieel minder schijfruimte, maar dezelfde hoeveelheid bandbreedte als een gewone Monero-installatie. Echter, het volledig opslaan van de Monero-blockchain is bevorderlijk voor de beveiliging van het Monero netwerk. Als u een apparaat gebruikt met beperkte schuifruimte is deze optie geschikt.</translation>
+        <translation>De modus voor schijfbehoud gebruikt substantieel minder schijfruimte, maar dezelfde hoeveelheid bandbreedte als een gewone Monero-installatie. Het volledig opslaan van de Monero-blockchain is echter beter voor de beveiliging van het Monero-netwerk. Deze optie is geschikt als u een apparaat gebruikt met beperkte schijfruimte.</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="157"/>
         <source>Allow background mining?</source>
-        <translation>Minen in de achtergrond toestaan?</translation>
+        <translation>Minen op de achtergrond toestaan?</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="175"/>
@@ -1928,14 +1620,6 @@ Graag upgraden of verbinden met een andere node</translation>
 </context>
 <context>
     <name>WizardCreateWallet</name>
-    <message>
-        <source>A new wallet has been created for you</source>
-        <translation type="vanished">Een nieuwe portemonnee is voor u aangemaakt</translation>
-    </message>
-    <message>
-        <source>This is the 25 word mnemonic for your wallet</source>
-        <translation type="vanished">Dit is de hersteltekst voor uw portemonnee, bestaande uit 25 woorden</translation>
-    </message>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
@@ -1997,17 +1681,9 @@ Graag upgraden of verbinden met een andere node</translation>
         <translation>Taal</translation>
     </message>
     <message>
-        <source>Account name</source>
-        <translation type="vanished">Portemonnee naam</translation>
-    </message>
-    <message>
-        <source>Seed</source>
-        <translation type="vanished">Hersteltekst</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Wallet name</source>
-        <translation>Portemonnee naam</translation>
+        <translation>Naam van portemonnee</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="60"/>
@@ -2017,12 +1693,12 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="61"/>
         <source>Wallet path</source>
-        <translation>Portemonnee locatie</translation>
+        <translation>Locatie van portemonnee</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="67"/>
         <source>Daemon address</source>
-        <translation>Node adres</translation>
+        <translation>Node-adres</translation>
     </message>
     <message>
         <location filename="../wizard/WizardFinish.qml" line="68"/>
@@ -2045,17 +1721,9 @@ Graag upgraden of verbinden met een andere node</translation>
         <translation>Vergeet u hersteltekst niet op te schrijven. U kunt u hersteltekst bekijken en instellingen aanpassen op de instellingen pagina.</translation>
     </message>
     <message>
-        <source>An overview of your Monero configuration is below:</source>
-        <translation type="vanished">Een overzicht van uw Monero-configuratie staat hieronder:</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardFinish.qml" line="128"/>
         <source>You’re all set up!</source>
         <translation>U bent klaar met configureren!</translation>
-    </message>
-    <message>
-        <source>You’re all setup!</source>
-        <translation type="vanished">U bent klaar!</translation>
     </message>
 </context>
 <context>
@@ -2063,7 +1731,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardMain.qml" line="176"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
-        <translation>Een portemonnee met dezelfde naam bestaat reeds. Verander alstublieft de naam van uw portemonnee</translation>
+        <translation>Er bestaat al een portemonnee met dezelfde naam. Verander de naam van uw portemonnee</translation>
     </message>
     <message>
         <location filename="../wizard/WizardMain.qml" line="184"/>
@@ -2089,12 +1757,8 @@ Graag upgraden of verbinden met een andere node</translation>
         <location filename="../wizard/WizardMain.qml" line="394"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in:
-%1</source>
-        <translation type="vanished">De alleen-lezen portemonnee is aangemaakt. U kunt deze openen door de huidige portemonnee te sluiten, klik vervolgens op &quot;Open een portemonnee vanaf een bestand&quot;, en selecteer de alleen-lezen portemonnee in:
+        <translatorcomment>The exact option text is: Open a wallet from file</translatorcomment>
+        <translation>De alleen-lezen portemonnee is aangemaakt. U opent deze als volgt: sluit de huidige portemonnee, klik vervolgens op &quot;Open een portemonnee vanuit een bestand&quot; en selecteer de alleen-lezen portemonnee in:
 %1</translation>
     </message>
     <message>
@@ -2111,36 +1775,24 @@ Graag upgraden of verbinden met een andere node</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <source>This is the name of your wallet. You can change it to a different name if you’d like:</source>
-        <translation type="vanished">Dit is de naam van uw portemonnee. U kunt de naam veranderen mocht u dat willen:</translation>
-    </message>
-    <message>
-        <source>My account name</source>
-        <translation type="vanished">Mijn portemonnee-naam:</translation>
-    </message>
-    <message>
-        <source>Restore height</source>
-        <translation type="vanished">Herstelpunt (blokhoogte)</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
         <source>Wallet name</source>
-        <translation>Portemonnee naam</translation>
+        <translation>Naam van portemonnee</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
         <source>Restore from seed</source>
-        <translation>Herstel met behulp van hersteltekst</translation>
+        <translation>Herstel met hersteltekst</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
         <source>Restore from keys</source>
-        <translation>Herstel met behulp van sleutels</translation>
+        <translation>Herstel met sleutels</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
         <source>Account address (public)</source>
-        <translation>Portemonnee adres (openbaar)</translation>
+        <translation>Adres van portemonnee (openbaar)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
@@ -2150,7 +1802,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
         <source>Spend key (private)</source>
-        <translation>Bestedings-sleutel (privé)</translation>
+        <translation>Bestedingssleutel (privé)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
@@ -2171,14 +1823,6 @@ Graag upgraden of verbinden met een andere node</translation>
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <source>It is very important to write it down as this is the only backup you will need for your wallet. You will be asked to confirm the seed in the next screen to ensure it has copied down correctly.</source>
-        <translation type="vanished">Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee. Op de volgende pagina wordt gevraagd om de hersteltekst te bevestigen om ervoor te zorgen dat de tekst op de juiste manier is overgenomen.</translation>
-    </message>
-    <message>
-        <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
-        <translation type="vanished">Het is erg belangrijk om dit op te schrijven omdat dit de enige back-up is die u nodig heeft voor uw portemonnee..</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
         <source>Enter your 25 word mnemonic seed</source>
         <translation>Vul u hersteltekst van 25 woorden in</translation>
@@ -2186,7 +1830,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
-        <translation>Deze hersteltekst is &lt;b&gt;zeer&lt;/b&gt; belangerijk om veilig op te slaag en privé te houden. Het is het enigste wat u (nodig) heeft om uw portemonnee te backuppen of te herstellen.</translation>
+        <translation>Deze hersteltekst is &lt;b&gt;zeer&lt;/b&gt; belangrijk om veilig op te slaan en privé te houden. Het is het enige dat u nodig heeft om een back-up van uw portemonnee te maken of uw portemonnee te herstellen.</translation>
     </message>
 </context>
 <context>
@@ -2199,7 +1843,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="98"/>
         <source>Please select one of the following options:</source>
-        <translation>Selecteer alstublieft een van de volgende opties:</translation>
+        <translation>Selecteer een van de volgende opties:</translation>
     </message>
     <message>
         <location filename="../wizard/WizardOptions.qml" line="155"/>
@@ -2222,22 +1866,6 @@ Graag upgraden of verbinden met een andere node</translation>
         <translation>Aangepast node-adres (optioneel)</translation>
     </message>
     <message>
-        <source>This is my first time, I want to create a new account</source>
-        <translation type="vanished">Dit is mijn eerste keer, ik wil een nieuwe portemonnee aanmaken</translation>
-    </message>
-    <message>
-        <source>I want to recover my account from my 25 word seed</source>
-        <translation type="vanished">Ik wil mijn portemonnee herstellen met de hersteltekst van 25 woorden</translation>
-    </message>
-    <message>
-        <source>I want to open a wallet from file</source>
-        <translation type="vanished">Ik wil een portemonnee openen vanuit een bestand</translation>
-    </message>
-    <message>
-        <source>Please setup daemon address below.</source>
-        <translation type="vanished">Stel hieronder alstublieft het node-adres in.</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardOptions.qml" line="295"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
@@ -2245,28 +1873,6 @@ Graag upgraden of verbinden met een andere node</translation>
 </context>
 <context>
     <name>WizardPassword</name>
-    <message>
-        <source>Now that your wallet has been created, please set a password for the wallet</source>
-        <translation type="vanished">Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
-    </message>
-    <message>
-        <source>Now that your wallet has been restored, please set a password for the wallet</source>
-        <translation type="vanished">Nu dat uw portemonnee is aangemaakt, moet u deze beveiligen met een wachtwoord</translation>
-    </message>
-    <message>
-        <source>Note that this password cannot be recovered, and if forgotten you will need to restore your wallet from the mnemonic seed you were just given&lt;br/&gt;&lt;br/&gt;
-                        Your password will be used to protect your wallet and to confirm actions, so make sure that your password is sufficiently secure.</source>
-        <translation type="vanished">Het wachtwoord kan niet hersteld worden, mocht u het wachtwoord vergeten dan moet u uw portemonnee herstellen via de hersteltekst van 25 woorden die u zojuist heeft gekregen&lt;br/&gt;&lt;br/&gt;
-                        Uw wachtwoord wordt gebruikt om uw portemonnee te beveiligen en acties te bevestigen, dus zorg ervoor dat uw wachtwoord voldoende veilig is.</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Wachtwoord</translation>
-    </message>
-    <message>
-        <source>Confirm password</source>
-        <translation type="vanished">Wachtwoord bevestigen</translation>
-    </message>
     <message>
         <location filename="../wizard/WizardPassword.qml" line="57"/>
         <location filename="../wizard/WizardPassword.qml" line="59"/>
@@ -2278,12 +1884,6 @@ Graag upgraden of verbinden met een andere node</translation>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Let op: dit wachtwoord kan niet hersteld worden. Als u het wachtwoord vergeet, kan de portemonnee alleen hersteld worden worden met u hersteltekst van 25 woorden.&lt;br/&gt;&lt;br/&gt;
-                        &lt;b&gt;Vul een sterk wachtwoord in&lt;/b&gt; (gebruik letters, cijfers, en/of symbolen):</translation>
-    </message>
-    <message>
-        <source>Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
-                        &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
-        <translation type="vanished">Let op: dit wachtwoord kan niet hersteld worden. Als u het wachtwoord vergeet, kan de portemonnee alleen hersteld worden worden met u hersteltekst van 25 woorden.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Vul een sterk wachtwoord in&lt;/b&gt; (gebruik letters, cijfers, en/of symbolen):</translation>
     </message>
 </context>
@@ -2303,14 +1903,6 @@ Graag upgraden of verbinden met een andere node</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <source>We&apos;re ready to recover your account</source>
-        <translation type="vanished">Uw portemonnee kan hersteld worden</translation>
-    </message>
-    <message>
-        <source>Please enter your 25 word private key</source>
-        <translation type="vanished">Vul alstublieft de 25 woorden van de hersteltekst in</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
         <source>Restore wallet</source>
         <translation>Portemonnee herstellen</translation>
@@ -2319,10 +1911,6 @@ Graag upgraden of verbinden met een andere node</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <source>Welcome</source>
-        <translation type="vanished">Welkom</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardWelcome.qml" line="79"/>
         <source>Welcome to Monero!</source>
         <translation>Welkom bij Monero!</translation>
@@ -2330,7 +1918,7 @@ Graag upgraden of verbinden met een andere node</translation>
     <message>
         <location filename="../wizard/WizardWelcome.qml" line="89"/>
         <source>Please choose a language and regional format.</source>
-        <translation>Selecteer alstublieft een taal en regio.</translation>
+        <translation>Selecteer een taal en regio.</translation>
     </message>
 </context>
 <context>
@@ -2355,10 +1943,6 @@ Graag upgraden of verbinden met een andere node</translation>
         <translation>Portemonnee kan niet geopend worden: </translation>
     </message>
     <message>
-        <source>Synchronizing blocks %1 / %2</source>
-        <translation type="vanished">Blokken synchroniseren %1 / %2</translation>
-    </message>
-    <message>
         <location filename="../main.qml" line="493"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transactie kan niet worden aangemaakt: Verkeerde node-versie: </translation>
@@ -2367,15 +1951,14 @@ Graag upgraden of verbinden met een andere node</translation>
         <location filename="../main.qml" line="504"/>
         <location filename="../main.qml" line="617"/>
         <source>No unmixable outputs to sweep</source>
-        <translatorcomment>Lastig te vertalen, iemand een beter idéé?</translatorcomment>
-        <translation type="unfinished">Er zijn geen niet te mengen bedragen gevonden die opgeschoond kunnen worden</translation>
+        <translation>Geen onmengbare bedragen gevonden om samen te voegen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="517"/>
         <location filename="../main.qml" line="630"/>
         <source>Please confirm transaction:
 </source>
-        <translation>Gelieve de transactie te bevestigen:
+        <translation>Bevestig de transactie:
 </translation>
     </message>
     <message>
@@ -2386,22 +1969,14 @@ Graag upgraden of verbinden met een andere node</translation>
 Amount: </source>
         <translation>
 
-Bedrag:</translation>
-    </message>
-    <message>
-        <source>
-
-Mixin: </source>
-        <translation type="obsolete">
-
-Menging:</translation>
+Bedrag: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="523"/>
         <source>
 Number of transactions: </source>
         <translation>
-Aantal transacties:</translation>
+Aantal transacties: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="524"/>
@@ -2410,7 +1985,7 @@ Aantal transacties:</translation>
 Description: </source>
         <translation>
 
-Omschrijving:</translation>
+Omschrijving: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="554"/>
@@ -2420,7 +1995,7 @@ Omschrijving:</translation>
     <message>
         <location filename="../main.qml" line="678"/>
         <source>Money sent successfully: %1 transaction(s) </source>
-        <translation>Geld succesvol verzonden: %1 transactie(s)</translation>
+        <translation>Het geld is verzonden: %1 transactie(s) </translation>
     </message>
     <message>
         <location filename="../main.qml" line="718"/>
@@ -2431,10 +2006,6 @@ Omschrijving:</translation>
         <location filename="../main.qml" line="723"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Dit adres heeft %1 monero ontvangen, maar de transactie is nog niet verwerkt</translation>
-    </message>
-    <message>
-        <source>This address received %1 monero, with %2 confirmations</source>
-        <translation type="vanished">Dit adres heeft %1 monero ontvangen, met %2 bevestigingen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="732"/>
@@ -2480,7 +2051,7 @@ Omschrijving:</translation>
     <message>
         <location filename="../main.qml" line="439"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
-        <translation>Graag u portemonnee en node log controleren op fouten. U kunt ook proberen %1 handmatig te starten.</translation>
+        <translation>Controleer de logs van uw portemonnee en node op fouten. Of probeer %1 handmatig te starten.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="516"/>
@@ -2493,7 +2064,7 @@ Omschrijving:</translation>
         <source>
 Address: </source>
         <translation>
-Adres:</translation>
+Adres: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="519"/>
@@ -2501,12 +2072,6 @@ Adres:</translation>
 Payment ID: </source>
         <translation>
 Betaal-ID: </translation>
-    </message>
-    <message>
-        <source>
-Amount: </source>
-        <translation type="vanished">
-Bedrag: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="521"/>
@@ -2528,12 +2093,12 @@ Ringgrootte: </translation>
     <message>
         <location filename="../main.qml" line="566"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
-        <translation>onvoldoende fondsen. Beschikbaar saldo: %1</translation>
+        <translation>Onvoldoende geld. Beschikbaar saldo: %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="669"/>
         <source>Couldn&apos;t send the money: </source>
-        <translation>Geld kon niet worden verstuurd:</translation>
+        <translation>Het geld kan niet worden verstuurd: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="672"/>
@@ -2543,12 +2108,12 @@ Ringgrootte: </translation>
     <message>
         <location filename="../main.qml" line="678"/>
         <source>Transaction saved to file: %1</source>
-        <translation>Transactie opgeslagen naar bestand: %1</translation>
+        <translation>Transactie opgeslagen in bestand: %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="728"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
-        <translation>Did adres heeft %1 monero ontvangen, met %2 bevestiging(en).</translation>
+        <translation>Dit adres heeft %1 monero ontvangen, met %2 bevestiging(en).</translation>
     </message>
     <message>
         <location filename="../main.qml" line="744"/>
@@ -2588,7 +2153,7 @@ Ringgrootte: </translation>
     <message>
         <location filename="../main.qml" line="1318"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
-        <translation>Node zal nog steeds in de achtergrond blijven lopen als de GUI gesloten is.</translation>
+        <translation>Node wordt nog steeds op de achtergrond uitgevoerd nadat de GUI gesloten wordt.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1320"/>


### PR DESCRIPTION
This is based on the cleaned up source text from PR #788 and should be merged after that.

Changes:
- Translated some new strings.
- Removed spaces in compound nouns.
- Made the form of address consistently formal (je->u).
- Improved grammar and style in longer text.
- Removed overly formal words like 'gelieve' and 'alstublieft'.
- For the verb *Sign*, changed 'Signeren' to 'Ondertekenen'.