### PR TITLE
Fix verifySignatureLine positioning

### DIFF
--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -443,7 +443,6 @@ Rectangle {
                     id: verifySignatureLabel
                     fontSize: 14
                     text: qsTr("Signature") + translationManager.emptyString
-                    Layout.fillWidth: true
                 }
 
                 LineEdit {
@@ -451,7 +450,6 @@ Rectangle {
                     fontSize: mainLayout.lineEditFontSize
                     placeholderText: qsTr("Signature") + translationManager.emptyString;
                     Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignLeft
 
                     IconButton {
                         imageSource: "../images/copyToClipboard.png"


### PR DESCRIPTION
Fixes the positioning of `verifySignatureLine` LineEdit. See screenshot below. Fixes #767

![verifySignatureLine](https://user-images.githubusercontent.com/7271470/29922427-dc8c338c-8e55-11e7-9517-cb13801c436a.png)
