### PR TITLE
Superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [LICENSE](LICENSE).
 
 Packages are available for
 
-* Arch Linux via AUR: [monero-core-git](https://aur.archlinux.org/packages/monero-core-git/)
+* Arch Linux via AUR: [monero-wallet-qt](https://aur.archlinux.org/packages/monero-wallet-qt/)
 
 Packaging for your favorite distribution would be a welcome contribution!
 


### PR DESCRIPTION
Superseded according to package maintainer "redfish":

>redfish commented on 2017-08-20 08:49
>Package marked for deletion. Superceded by: monero-wallet-qt