### PR TITLE
pro: add libreadline to link line for Linux

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -91,7 +91,8 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lwallet_merged \
         -lepee \
         -lunbound \
-        -leasylogging
+        -leasylogging \
+        -lreadline \
 }
 
 


### PR DESCRIPTION
Otherwise linking fails with undefined symbols `rl_*` (at least on Arch Linux x86_64).

Probably also needed for iOS case below (near -lepee), but I can't test iOS, so not adding that to this PR.
