### PR TITLE
Fix weird behaviour of privacy level bar

### DIFF
--- a/components/PrivacyLevel.qml
+++ b/components/PrivacyLevel.qml
@@ -95,7 +95,7 @@ Item {
                     }
                 }
 
-                if(index !== -1) {
+                if(index !== -1 && index !== 4) {
                     fillRect.width = Qt.binding(function(){ return row.positions[index].currentX + row.x })
                     item.fillLevel = index
                 }


### PR DESCRIPTION
This PR fixes the weird behaviour of the privacy level bar described in #863. I fixed it by hiding the ring size of 9, so it's a bit of a hack. The actual bug is that the ring size of 9 is too close to the 8. Couldn't get it to work right now as I'm still new to QT.

Fixes #863