### PR TITLE
README: Add package installation instructions for Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See [LICENSE](LICENSE).
 Packages are available for
 
 * Arch Linux via AUR: [monero-wallet-qt](https://aur.archlinux.org/packages/monero-wallet-qt/)
+* Void Linux: xbps-install -S monero-core
 
 Packaging for your favorite distribution would be a welcome contribution!
 


### PR DESCRIPTION
The package has recently been accepted into the repository, voidlinux/void-packages@4b6fa3867064d3f10b552392414518b00b6eff92 .