### PR TITLE
Run get_libwallet_api.sh using its own shebang

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ if [[ $platform == *bsd* ]]; then
 fi
 
 # build libwallet
-$SHELL get_libwallet_api.sh $BUILD_TYPE
+./get_libwallet_api.sh $BUILD_TYPE
  
 # build zxcvbn
 $MAKE -C src/zxcvbn-c || exit


### PR DESCRIPTION
Not every system has bash as default shell. Running this script in zsh environment leads to build failure.