### PR TITLE
don't copy libjasper-1.dll

### DIFF
--- a/windeploy_helper.sh
+++ b/windeploy_helper.sh
@@ -23,7 +23,7 @@ else
 	ICU_FILES=(libicuucd57.dll libicuind57.dll libicudtd57.dll)
 fi
 
-FILES=(zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libjasper-1.dll libintl-8.dll  libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll)
+FILES=(zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libintl-8.dll libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll)
 
 platform=$(get_platform)
 


### PR DESCRIPTION
See #900. Wasn't included in v0.11.0 release with no apparent notice or ill-effects. If someone thinks this is still needed, please comment. We seemed to be including this file which is written, licensed and built by another project. No reply from @mbg033 who first included it.

I will open an issue to examine the rest of the $FILES in windeployhelper.sh